### PR TITLE
Start adding Empty type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -7,6 +7,11 @@ using HDF5
 using Strided
 
 #####################################
+# Exports
+#
+include("exports.jl")
+
+#####################################
 # DenseTensor and DiagTensor
 #
 include("tupletools.jl")
@@ -32,5 +37,10 @@ include("blocksparse/blocksparsetensor.jl")
 include("blocksparse/diagblocksparse.jl")
 include("blocksparse/combiner.jl")
 include("blocksparse/linearalgebra.jl")
+
+#####################################
+# Empty
+#
+include("empty.jl")
 
 end # module NDTensors

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -14,19 +14,26 @@ export Dense,
 # Dense storage
 #
 
-struct Dense{ElT,VecT<:AbstractVector} <: TensorStorage{ElT}
+struct Dense{ElT, VecT<:AbstractVector} <: TensorStorage{ElT}
   data::VecT
-  function Dense{ElT,VecT}(data) where {ElT,VecT<:AbstractVector{ElT}}
-    return new{ElT,VecT}(data)
+  function Dense{ElT, VecT}(data::AbstractVector) where {ElT,
+                                                         VecT<:AbstractVector{ElT}}
+    return new{ElT, VecT}(data)
   end
 end
 
-function Dense(data::VecT) where {VecT<:AbstractVector{ElT}} where {ElT}
+function Dense(data::VecT) where {VecT <: AbstractVector{ElT}} where {ElT}
   return Dense{ElT,VecT}(data)
 end
 
 function Dense{ElR}(data::AbstractVector{ElT}) where {ElR,ElT}
   ElT == ElR ? Dense(data) : Dense(ElR.(data))
+end
+
+# Construct from a set of indices
+function Dense{ElT, VecT}(inds) where {ElT,
+                                       VecT <: AbstractVector{ElT}}
+  return Dense(VecT(dim(inds)))
 end
 
 Dense{ElT}(dim::Integer) where {ElT} = Dense(zeros(ElT,dim))

--- a/src/diag.jl
+++ b/src/diag.jl
@@ -186,6 +186,11 @@ function Base.Array(T::DiagTensor{ElT,N}) where {ElT,N}
   return Array{ElT,N}(T)
 end
 
+function Base.zeros(TensorT::Type{<: DiagTensor},
+                    inds)
+  return tensor(zeros(storetype(TensorT), mindim(inds)), inds)
+end
+
 # Needed to get slice of DiagTensor like T[1:3,1:3]
 function Base.similar(T::DiagTensor{<:Number,N},
                       ::Type{ElR},

--- a/src/empty.jl
+++ b/src/empty.jl
@@ -25,6 +25,10 @@ const EmptyTensor{ElT,
                                   StoreT,
                                   IndsT} where {StoreT <: Empty}
 
+# If no indices are provided, the tensor has Any number of
+# indices
+tensor(S::Empty, ::Nothing) = Tensor{eltype(S), Any, typeof(S), Nothing}(nothing, S)
+
 # From an EmptyTensor, return the closest Tensor type
 function Base.fill(::Type{<:Tensor{ElT, N, EStoreT, IndsT}}) where {ElT,
                                                                     N,

--- a/src/empty.jl
+++ b/src/empty.jl
@@ -1,0 +1,58 @@
+export Empty,
+       EmptyTensor
+
+#
+# Empty storage
+#
+
+struct Empty{ElT, StoreT <: TensorStorage} <: TensorStorage{ElT}
+end
+
+# Defaults to Dense
+Empty{ElT}() where {ElT} = Empty{ElT, Dense{ElT, Vector{ElT}}}()
+
+Empty() = Empty{Float64}()
+
+#
+# EmptyTensor (Tensor using Empty storage)
+#
+
+const EmptyTensor{ElT,
+                  N,
+                  StoreT,
+                  IndsT} = Tensor{ElT,
+                                  N,
+                                  StoreT,
+                                  IndsT} where {StoreT <: Empty}
+
+# From an EmptyTensor, return the closest Tensor type
+function Base.fill(::Type{<:Tensor{ElT, N, EStoreT, IndsT}}) where {ElT,
+                                                                    N,
+                                                                    EStoreT <: Empty{ElT, StoreT},
+                                                                    IndsT} where {StoreT}
+  return Tensor{ElT, N, StoreT, IndsT}
+end
+
+Base.@propagate_inbounds function Base.setindex(T::EmptyTensor{<:Number, N},
+                                                x::Number,
+                                                I::Vararg{Int, N}) where {N}
+  R = zeros(fill(typeof(T)), inds(T))
+  R[I...] = x
+  return R
+end
+
+setindex!!(T::EmptyTensor, x::Number, I::Int...) = setindex(T, x, I...)
+
+function Base.show(io::IO,
+                   mime::MIME"text/plain",
+                   ::Empty)
+  nothing
+end
+
+function Base.show(io::IO,
+                   mime::MIME"text/plain",
+                   T::EmptyTensor)
+  summary(io, T)
+  println(io)
+end
+

--- a/src/empty.jl
+++ b/src/empty.jl
@@ -1,5 +1,3 @@
-export Empty,
-       EmptyTensor
 
 #
 # Empty storage
@@ -8,16 +6,36 @@ export Empty,
 struct Empty{ElT, StoreT <: TensorStorage} <: TensorStorage{ElT}
 end
 
-# Defaults to Dense
-Empty{ElT}() where {ElT} = Empty{ElT, Dense{ElT, Vector{ElT}}}()
+# Get the Empty version of the TensorStorage
+function empty(::Type{StoreT}) where {StoreT <: TensorStorage{ElT}} where {ElT}
+  return Empty{ElT, StoreT}
+end
 
-Empty() = Empty{Float64}()
+# Defaults to Dense
+function Empty(::Type{ElT}) where {ElT}
+  return empty(Dense{ElT, Vector{ElT}})()
+end
+
+Empty() = Empty(Float64)
 
 Base.copy(S::Empty) = S
 
 Base.isempty(::Empty) = true
 
-Base.size(::Empty) = 0
+nnzblocks(::Empty) = 0
+
+nnz(::Empty) = 0
+
+function Base.complex(::Type{<: Empty{ElT, StoreT}}) where {ElT,
+                                                            StoreT}
+  return Empty{complex(ElT), complex(StoreT)}
+end
+
+function Base.complex(S::Empty)
+  return complex(typeof(S))()
+end
+
+#Base.size(::Empty) = 0
 
 function Base.show(io::IO,
                    mime::MIME"text/plain",
@@ -39,25 +57,55 @@ const EmptyTensor{ElT,
 
 Base.isempty(::EmptyTensor) = true
 
-Base.size(::EmptyTensor) = 0
+function EmptyTensor(::Type{ElT}, inds) where {ElT <: Number}
+  return tensor(Empty(ElT), inds)
+end
+
+function EmptyTensor(::Type{StoreT}, inds) where {StoreT <: TensorStorage}
+  return tensor(empty(StoreT)(), inds)
+end
+
+function EmptyBlockSparseTensor(::Type{ElT}, inds) where {ElT <: Number}
+  StoreT = BlockSparse{ElT, Vector{ElT}, length(inds)}
+  return EmptyTensor(StoreT, inds)
+end
 
 # From an EmptyTensor, return the closest Tensor type
-function Base.fill(::Type{<:Tensor{ElT, N, EStoreT, IndsT}}) where {ElT,
-                                                                    N,
-                                                                    EStoreT <: Empty{ElT, StoreT},
-                                                                    IndsT} where {StoreT}
+function Base.fill(::Type{<: Tensor{ElT,
+                                    N,
+                                    EStoreT,
+                                    IndsT}}) where {ElT <: Number,
+                                                    N,
+                                                    EStoreT <: Empty{ElT,
+                                                                     StoreT},
+                                                    IndsT} where {StoreT}
   return Tensor{ElT, N, StoreT, IndsT}
 end
 
-Base.@propagate_inbounds function Base.setindex(T::EmptyTensor{<:Number, N},
+function Base.zeros(T::TensorT) where {TensorT <: EmptyTensor}
+  TensorR = fill(TensorT)
+  return zeros(TensorR, inds(T))
+end
+
+function addblock(T::EmptyTensor{<: Number, N},
+                  block::Block{N}) where {N}
+  R = zeros(T)
+  addblock!(R, block)
+  return R
+end
+
+addblock!!(T::EmptyTensor{<: Number, N},
+           block::Block{N}) where {N} = addblock(T, block)
+
+Base.@propagate_inbounds function Base.setindex(T::EmptyTensor{<: Number, N},
                                                 x::Number,
                                                 I::Vararg{Int, N}) where {N}
-  R = zeros(fill(typeof(T)), inds(T))
+  R = zeros(T)
   R[I...] = x
   return R
 end
 
-function Base.setindex(T::EmptyTensor{<:Number, Any},
+function Base.setindex(T::EmptyTensor{<: Number, Any},
                                       x::Number,
                                       I::Int...)
   error("Setting element of EmptyTensor with Any number of dimensions not defined")

--- a/src/empty.jl
+++ b/src/empty.jl
@@ -13,6 +13,18 @@ Empty{ElT}() where {ElT} = Empty{ElT, Dense{ElT, Vector{ElT}}}()
 
 Empty() = Empty{Float64}()
 
+Base.copy(S::Empty) = S
+
+Base.isempty(::Empty) = true
+
+Base.size(::Empty) = 0
+
+function Base.show(io::IO,
+                   mime::MIME"text/plain",
+                   S::Empty)
+  println(io, typeof(S))
+end
+
 #
 # EmptyTensor (Tensor using Empty storage)
 #
@@ -25,9 +37,9 @@ const EmptyTensor{ElT,
                                   StoreT,
                                   IndsT} where {StoreT <: Empty}
 
-# If no indices are provided, the tensor has Any number of
-# indices
-tensor(S::Empty, ::Nothing) = Tensor{eltype(S), Any, typeof(S), Nothing}(nothing, S)
+Base.isempty(::EmptyTensor) = true
+
+Base.size(::EmptyTensor) = 0
 
 # From an EmptyTensor, return the closest Tensor type
 function Base.fill(::Type{<:Tensor{ElT, N, EStoreT, IndsT}}) where {ElT,
@@ -45,13 +57,15 @@ Base.@propagate_inbounds function Base.setindex(T::EmptyTensor{<:Number, N},
   return R
 end
 
-setindex!!(T::EmptyTensor, x::Number, I::Int...) = setindex(T, x, I...)
-
-function Base.show(io::IO,
-                   mime::MIME"text/plain",
-                   ::Empty)
-  nothing
+function Base.setindex(T::EmptyTensor{<:Number, Any},
+                                      x::Number,
+                                      I::Int...)
+  error("Setting element of EmptyTensor with Any number of dimensions not defined")
 end
+
+setindex!!(T::EmptyTensor,
+           x::Number,
+           I::Int...) = setindex(T, x, I...)
 
 function Base.show(io::IO,
                    mime::MIME"text/plain",

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,3 +1,9 @@
-export setindex,
-       setindex!!
+export addblock!!,
+       setindex,
+       setindex!!,
+
+# empty.jl
+       Empty,
+       EmptyTensor,
+       EmptyBlockSparseTensor
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,0 +1,3 @@
+export setindex,
+       setindex!!
+

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -306,6 +306,8 @@ end
 # Some generic getindex and setindex! functionality
 #
 
+setindex!!(T::Tensor, x::Number, I...) = setindex!(T, x, I...)
+
 """
 getdiagindex
 
@@ -358,12 +360,13 @@ find_tensor(::Any, rest) = find_tensor(rest)
 
 function Base.summary(io::IO,
                       T::Tensor)
-  println(io,typeof(inds(T)))
-  for (dim,ind) in enumerate(inds(T))
-    println(io,"Dim $dim: ",ind)
+  println(io, typeof(T))
+  println(io, "inds type = ", typeof(inds(T)))
+  for (dim, ind) in enumerate(inds(T))
+    println(io, "Dim $dim: ", ind)
   end
-  println(io,typeof(store(T)))
-  println(io," ",Base.dims2string(dims(T)))
+  println(io, "store type = ", typeof(store(T)))
+  println(io, " ", Base.dims2string(dims(T)))
 end
 
 #

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -12,7 +12,7 @@ interface and no assumption of labels)
 """
 struct Tensor{ElT,
               N,
-              StoreT<:TensorStorage,
+              StoreT <: TensorStorage,
               IndsT} <: AbstractArray{ElT,N}
   store::StoreT
   inds::IndsT
@@ -66,7 +66,13 @@ store(T::Tensor) = T.store
 
 data(T::Tensor) = data(store(T))
 
-storetype(::Tensor{ElT,N,StoreT}) where {ElT,N,StoreT} = StoreT
+storetype(::Tensor{<: Number,
+                   <: Any,
+                   StoreT}) where {StoreT} = StoreT
+
+storetype(::Type{<: Tensor{<: Number,
+                           <: Any,
+                           StoreT}}) where {StoreT} = StoreT
 
 inds(T::Tensor) = T.inds
 
@@ -163,15 +169,9 @@ function Base.convert(::Type{<:Tensor{<:Number,N,StoreR,Inds}},
   return tensor(convert(StoreR,store(T)),inds(T))
 end
 
-function Base.zeros(::Type{<:Tensor{ElT,N,StoreT}},
+function Base.zeros(TensorT::Type{<:Tensor{ElT,N,StoreT}},
                     inds) where {ElT,N,StoreT}
-  return tensor(zeros(StoreT,dim(inds)),inds)
-end
-
-# This is to fix a method ambiguity with a Base array function
-function Base.zeros(::Type{<:Tensor{ElT,N,StoreT}},
-                    inds::Dims{N}) where {ElT,N,StoreT}
-  return tensor(zeros(StoreT,dim(inds)),inds)
+  error("zeros(::Type{$TensorT}, inds) not implemented yet")
 end
 
 function Base.promote_rule(::Type{<:Tensor{ElT1,N1,StoreT1,IndsT1}},
@@ -214,6 +214,8 @@ end
 array(T::Tensor) = array(dense(T))
 matrix(T::Tensor{<:Number,2}) = array(T)
 vector(T::Tensor{<:Number,1}) = array(T)
+
+Base.isempty(T::Tensor) = isempty(store(T))
 
 #
 # Helper functions for BlockSparse-type storage
@@ -307,6 +309,8 @@ end
 #
 
 setindex!!(T::Tensor, x::Number, I...) = setindex!(T, x, I...)
+
+addblock!!(T::Tensor, block) = addblock!(T, block)
 
 """
 getdiagindex

--- a/src/tensorstorage.jl
+++ b/src/tensorstorage.jl
@@ -47,21 +47,25 @@ function Base.conj(S::T;always_copy = false) where {T<:TensorStorage}
   return T(conj(data(S)))
 end
 
-Base.complex(S::T) where {T<:TensorStorage} = complex(T)(complex(data(S)))
+function Base.complex(S::T) where {T <: TensorStorage}
+  return complex(T)(complex(data(S)))
+end
 
 Base.copyto!(S1::TensorStorage,
-             S2::TensorStorage) = (copyto!(data(S1),data(S2)); S1)
+             S2::TensorStorage) = (copyto!(data(S1), data(S2)); S1)
 
 Random.randn!(S::TensorStorage) = (randn!(data(S)); S)
 
-Base.fill!(S::TensorStorage,v) = (fill!(data(S),v); S)
+Base.fill!(S::TensorStorage, v) = (fill!(data(S), v); S)
 
-LinearAlgebra.rmul!(S::TensorStorage,v::Number) = (rmul!(data(S),v); S)
-scale!(S::TensorStorage,v::Number) = rmul!(S,v)
+LinearAlgebra.rmul!(S::TensorStorage,
+                    v::Number) = (rmul!(data(S), v); S)
+
+scale!(S::TensorStorage, v::Number) = rmul!(S, v)
 
 LinearAlgebra.norm(S::TensorStorage) = norm(data(S))
 
-Base.convert(::Type{T},S::T) where {T<:TensorStorage} = S
+Base.convert(::Type{T},S::T) where {T <: TensorStorage} = S
 
 blockoffsets(S::TensorStorage) = S.blockoffsets
 


### PR DESCRIPTION
This introduces a generic `Empty{ElT, StoreT}` storage type that is itself parametrized by a storage type `StoreT`. When an element of a `Tensor` with an `Empty` storage type is set, it returns a `Tensor` with a storage type `StoreT`. For example:
```julia
T = Tensor(Empty(), (2, 2))  # Empty() makes an Empty{Float64, Dense{Float64, ...}} storage
R = setindex!!(T, 2.3, 1, 1) # Returns a Dense Tensor R with all zeros except the 1,1 element
R[1, 1] == 2.3
R[1, 2] == 0.0
```

Additionally, a `Tensor` with an `Empty` storage type can be added to another `Tensor`, as a trivial additive identity (it returns a copy). This functionality has not been added yet.