### PR TITLE
Add TagBot Github Action

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,11 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds the TagBot Github Actions (https://github.com/marketplace/actions/julia-tagbot) which automatically makes a new tag for the correct commit when a new version is pushed to the Julia General registry. Seems like a good idea, then when we bump the version we just do it through the Julia registry with the Registrator (https://github.com/JuliaRegistries/Registrator.jl) and this makes sure the Github tags are synced.