### PR TITLE
implement random_unitary

### DIFF
--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -2,6 +2,7 @@ export eigs,
        entropy,
        polar,
        random_orthog,
+       random_unitary,
        Spectrum,
        svd,
        truncerror
@@ -220,6 +221,32 @@ function random_orthog(n::Int,m::Int)::Matrix
     if real(F.R[c,c]) < 0.0
       Q[:,c] *= -1
     end
+  end
+  return Q
+end
+
+"""
+    random_unitary(n::Int,m::Int)::Matrix
+
+Return a random complex matrix U of dimensions (n,m)
+such that if n >= m, U'*U is the
+identity, or if m > n U*U' is the
+identity.
+
+Sampling is based on https://arxiv.org/abs/math-ph/0609050
+such that in the case `n==m`, the unitary matrix will be sampled
+according to the Haar measure.
+"""
+function random_unitary(n::Int,m::Int)
+  if n < m
+    return Matrix(random_unitary(m,n)')
+  end
+  F = qr(randn(ComplexF64,n,m))
+  Q = Matrix(F.Q)
+  A = diag(Matrix(F.R))
+  A ./= abs.(A)
+  for c in 1:size(Q,2)
+      Q[:,c] *= A[c]
   end
   return Q
 end

--- a/test/linearalgebra.jl
+++ b/test/linearalgebra.jl
@@ -12,3 +12,14 @@ using LinearAlgebra
   @test norm(O2*transpose(O2) - Diagonal(fill(1.,n))) < 1E-14
 end
 
+@testset "random_unitary" begin
+  n,m = 10,4
+  U1 = random_unitary(n,m)
+  @test eltype(U1) <: ComplexF64
+  @test norm(U1'*U1 - Diagonal(fill(1.,m))) < 1E-14
+
+  n,m = 4,10
+  U2 = random_unitary(n,m)
+  @test norm(U2*U2' - Diagonal(fill(1.,n))) < 1E-14
+end
+


### PR DESCRIPTION
Needed for https://github.com/ITensor/ITensors.jl/issues/377  (and useful also for other use-cases). 
I implemented it in such a way that `random_unitary(n,n)` will sample according to the Haar measure (following https://arxiv.org/abs/math-ph/0609050, page 11).
