### PR TITLE
small fix to exp - extract parent matrix from Hermitian view

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -748,7 +748,7 @@ function LinearAlgebra.exp(T::DenseTensor{ElT,N},
   M = permute_reshape(T,Lpos,Rpos)
   indsTp = permute(inds(T), (Lpos...,Rpos...))
   if ishermitian
-    expM = exp(Hermitian(matrix(M)))
+    expM = parent(exp(Hermitian(matrix(M))))
     return tensor(Dense{ElT}(vec(expM)), indsTp)
   else
     expM = exp(M)


### PR DESCRIPTION
Extract the parent matrix from the Hermitian view in `exp(T, Linds, Rinds; ishermitian=true)`, similar to the way it is done in the case of the order 2 tensor `exp(T::Hermitian{ElT<:DenseTensor{ElT,2}})`. 
Without this fix one cannot use the ITensor returned from `exp`. 
