### PR TITLE
Fix uncombine bug when combined index is not first index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/src/blocksparse/combiner.jl
+++ b/src/blocksparse/combiner.jl
@@ -26,15 +26,15 @@ function contract(T::BlockSparseTensor,
     labelsRc = labelsT
     cpos_in_labelsRc = findfirst(==(clabel),labelsRc)
     # Move combined index to first position
-    #if cpos_in_labelsRc != 1
-    #  labelsRc_orig = labelsRc
-    #  labelsRc = deleteat(labelsRc,cpos_in_labelsRc)
-    #  labelsRc = insertafter(labelsRc,clabel,0)
-    #  cpos_in_labelsRc = 1
-    #  perm = getperm(labelsRc,labelsRc_orig)
-    #  T = permutedims(T,perm)
-    #  labelsT = permute(labelsT,perm)
-    #end
+    if cpos_in_labelsRc != 1
+      labelsRc_orig = labelsRc
+      labelsRc = deleteat(labelsRc,cpos_in_labelsRc)
+      labelsRc = insertafter(labelsRc,clabel,0)
+      cpos_in_labelsRc = 1
+      perm = getperm(labelsRc,labelsRc_orig)
+      T = permutedims(T,perm)
+      labelsT = permute(labelsT,perm)
+    end
     labelsRuc = insertat(labelsRc,labels_uc,cpos_in_labelsRc)
     indsRuc = contract_inds(inds(C),labelsC,inds(T),labelsT,labelsRuc)
     Ruc = uncombine(T,indsRuc,cpos_in_labelsRc,blockperm(C),blockcomb(C))


### PR DESCRIPTION
Uncombining led to errors when the combined index wasn't the first one, since the uncombine code has that built in as an assumption. This just permutes it to the first position, if it is not already in the first position (I guess the code to do that was already there, but commented out for some reason). 

I'm sure there are improvements and optimizations we can make to the combine and uncombine code. That will require a devoted effort at some point.