### PR TITLE
Outer kwargs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 
 [compat]
-HDF5 = "0.12.0, 0.13"
-StaticArrays = "0.12.0"
-Strided = "0.3.0"
+HDF5 = "0.12, 0.13"
+StaticArrays = "0.12"
+Strided = "0.3, 1"
 julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/src/blocksparse/blockdims.jl
+++ b/src/blocksparse/blockdims.jl
@@ -145,7 +145,7 @@ function blockdiaglength(inds,
   return minimum(blockdims(inds,block))
 end
 
-outer(dim1,dim2,dim3,dims...) = outer(outer(dim1,dim2),dim3,dims...)
+outer(dim1,dim2,dim3,dims...; kwargs...) = outer(outer(dim1,dim2),dim3,dims...; kwargs...)
 
 function outer(dim1::BlockDim,dim2::BlockDim)
   dimR = BlockDim(undef,nblocks(dim1)*nblocks(dim2))


### PR DESCRIPTION
Add keyword arguments to `outer`, for ITensors.jl compatibility.

Also bump version to v0.1.6.