### PR TITLE
Contraction logic bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/src/contraction_logic.jl
+++ b/src/contraction_logic.jl
@@ -333,7 +333,7 @@ function compute_contraction_properties!(props::ContractionProperties{NA,NB,NC},
     for k = 1:NC
       j = findfirst(==(props.ci[k]),props.ai)
       if !isnothing(j)
-        props.AtoC[newi] = k
+        props.AtoC[newi+1] = k
         props.PA[newi+1] = j
         newi += 1
       end

--- a/src/contraction_logic.jl
+++ b/src/contraction_logic.jl
@@ -10,18 +10,25 @@ function contract_labels(T1labels::Labels{N1},
     i < 0 && (ncont += 1)
   end
   NR = N1+N2-2*ncont
-  Rlabels = Vector{Int}(undef,NR)
+  ValNR = Val{NR}
+  return contract_labels(ValNR, T1labels, T2labels)
+end
+
+function contract_labels(::Type{Val{NR}},
+                         T1labels::Labels{N1},
+                         T2labels::Labels{N2}) where {NR,N1,N2}
+  Rlabels = MVector{NR,Int}(undef)
   u = 1
   # TODO: use Rlabels, don't assume ncon convention
-  @inbounds for i ∈ 1:N1
-    if(T1labels[i] > 0)
-      Rlabels[u] = T1labels[i];
+  for i in 1:N1
+    if T1labels[i] > 0
+      @inbounds Rlabels[u] = T1labels[i];
       u += 1
     end
   end
-  @inbounds for i ∈ 1:N2
-    if(T2labels[i] > 0)
-      Rlabels[u] = T2labels[i];
+  for i in 1:N2
+    if T2labels[i] > 0
+      @inbounds Rlabels[u] = T2labels[i];
       u += 1
     end
   end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -682,7 +682,7 @@ function _contract!(CT::DenseTensor{El, NC},
     CM = reshape(copy(C), props.dleft, props.dright)
   else
     if Ctrans(props)
-      CM = reshape(C, props.dleft, props.dright)
+      CM = reshape(C, props.dright, props.dleft)
       (AM, BM) = (BM, AM)
       if tA == tB
         tA = tB = (tA == 'T' ? 'N' : 'T')

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -41,7 +41,7 @@ end
 contains the (truncated) density matrix eigenvalue spectrum which is computed during a
 decomposition done by `svd` or `eigen`. In addition stores the truncation error.
 """
-struct Spectrum{VecT<:AbstractVector}
+struct Spectrum{VecT <: Union{AbstractVector, Nothing}}
   eigs::VecT
   truncerr::Float64
 end
@@ -51,7 +51,9 @@ truncerror(s::Spectrum) = s.truncerr
 
 function entropy(s::Spectrum)
   S = 0.0
-  for p in eigs(s)
+  eigs_s = eigs(s)
+  isnothing(eigs_s) && error("Spectrum does not contain any eigenvalues, cannot compute the entropy")
+  for p in eigs_s
     p > 1e-13 && (S -= p*log(p))
   end
   return S


### PR DESCRIPTION
This fixes some bugs in the contraction logic which only show up for more complicated in-place contractions. Basically they were off-by-one errors from the translation of the 0-based indexing used in C++ and the 1-based indexing used in Julia.

Also, this extends the definition of `Spectrum` to allow the eigenvalues to be `nothing`, for cases like QR where the eigenspectrum is not efficient enough to compute.