### PR TITLE
HDF5 Support for BlockSparse Storage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - '1.4'
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+        arch:
+          - x64
+        exclude:
+          # MacOS not available on x86
+          - {os: 'macOS-latest', arch: 'x86'}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,15 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 
+
 [compat]
 HDF5 = "0.12, 0.13"
 StaticArrays = "0.12"
 Strided = "0.3, 1"
 julia = "1.4"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/blocksparse/blocksparse.jl
+++ b/src/blocksparse/blocksparse.jl
@@ -280,8 +280,6 @@ function HDF5.read(parent::Union{HDF5File,HDF5Group},
   data = read(g,"data")
   off_array = read(g,"offsets")
   boff = array_to_offsets(off_array,N)
-  @show typeof(data)
-  @show typeof(boff)
   return BlockSparse(data,boff)
 end
 

--- a/test/blocksparse.jl
+++ b/test/blocksparse.jl
@@ -1,4 +1,4 @@
-using ITensors.NDTensors,
+using NDTensors,
       Test
 using LinearAlgebra
 

--- a/test/blocksparse.jl
+++ b/test/blocksparse.jl
@@ -315,3 +315,4 @@ using LinearAlgebra
 
 end
 
+nothing

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1,4 +1,4 @@
-using ITensors.NDTensors,
+using NDTensors,
       Test
 
 @testset "DenseTensor basic functionality" begin
@@ -112,3 +112,4 @@ end
   @test norm(Tc) ≉ 0
 end
 
+nothing

--- a/test/diag.jl
+++ b/test/diag.jl
@@ -1,4 +1,4 @@
-using ITensors.NDTensors,
+using NDTensors,
       Test
 
 @testset "DiagTensor basic functionality" begin
@@ -28,3 +28,5 @@ using ITensors.NDTensors,
   #@test permutedims(D, (2, 1)) == tensor(diagITensor(vr, j, i))
   #@test permutedims(tensor(diagITensor(2.0, j, i)), (2, 1)) == tensor(diagITensor(2.0, j, i))
 end
+
+nothing

--- a/test/linearalgebra.jl
+++ b/test/linearalgebra.jl
@@ -1,4 +1,4 @@
-using ITensors.NDTensors,
+using NDTensors,
       Test
 using LinearAlgebra
 
@@ -23,3 +23,4 @@ end
   @test norm(U2*U2' - Diagonal(fill(1.,n))) < 1E-14
 end
 
+nothing

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -1,0 +1,77 @@
+using NDTensors,
+      Test
+using HDF5
+
+@testset "Write to Disk and Read from Disk" begin
+
+  @testset "HDF5 readwrite Dense storage" begin
+    # Real case
+
+    D = randomTensor(3,4)
+
+    fo = h5open("data.h5","w")
+    write(fo,"D",D.store)
+    close(fo)
+
+    fi = h5open("data.h5","r")
+    rDstore = read(fi,"D",Dense{Float64})
+    close(fi)
+    @test rDstore ≈ D.store
+
+    # Complex case
+
+    D = randomTensor(ComplexF64,3,4)
+
+    fo = h5open("data.h5","w")
+    write(fo,"D",D.store)
+    close(fo)
+
+    fi = h5open("data.h5","r")
+    rDstore = read(fi,"D",Dense{ComplexF64})
+    close(fi)
+    @test rDstore ≈ D.store
+  end
+
+  @testset "HDF5 readwrite BlockSparse storage" begin
+    # Indices
+    indsA = ([2,3],[4,5])
+
+    # Locations of non-zero blocks
+    locs = [(1,2),(2,1)]
+
+    # Real case
+
+    B = randomBlockSparseTensor(locs,indsA)
+
+    fo = h5open("data.h5","w")
+    write(fo,"B",B.store)
+    close(fo)
+
+    fi = h5open("data.h5","r")
+    rBstore = read(fi,"B",BlockSparse{Float64})
+    close(fi)
+    @test rBstore ≈ B.store
+
+    # Complex case
+
+    B = randomBlockSparseTensor(ComplexF64,locs,indsA)
+
+    fo = h5open("data.h5","w")
+    write(fo,"B",B.store)
+    close(fo)
+
+    fi = h5open("data.h5","r")
+    rBstore = read(fi,"B",BlockSparse{ComplexF64})
+    close(fi)
+    @test rBstore ≈ B.store
+  end
+
+
+  #
+  # Clean up the test hdf5 file
+  #
+  rm("data.h5",force=true)
+
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,5 @@ using Test
     include(filename)
   end
 end
+
+nothing


### PR DESCRIPTION
This PR adds HDF5 readwrite support for BlockSparse storage and some supporting types. It also updates the unit tests for NDTensors to be a standalone library and adds the Github Actions workflow for running them.

- Add HDF5 support for BlockSparse storage
- Remove extra printing statements
- Add unit tests for HDF5 support of storage types
- Update unit tests for NDTensors to be standalone
- Add unit testing Github action workflow
