### PR TITLE
Speed up very small tensor contractions a little bit

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -641,23 +641,26 @@ function _contract!(CT::DenseTensor{El, NC},
                     α::Number = one(El),
                     β::Number = zero(El)) where {El, NC, NA, NB}
   # TODO: directly use Tensor instead of Array
-  C = array(CT)
-  A = array(AT)
-  B = array(BT)
+  C = Base.ReshapedArray(data(store(CT)), dims(inds(CT)), ())
+  A = Base.ReshapedArray(data(store(AT)), dims(inds(AT)), ())
+  B = Base.ReshapedArray(data(store(BT)), dims(inds(BT)), ())
 
   tA = 'N'
   if props.permuteA
     pA = NTuple{NA, Int}(props.PA)
     @strided Ap = permutedims(A, pA)
-    AM = reshape(Ap, props.dmid, props.dleft)
+    #AM = reshape(Ap, props.dmid, props.dleft)
+    AM = Base.ReshapedArray(Ap, (props.dmid, props.dleft), ())
     tA = 'T'
   else
     #A doesn't have to be permuted
     if Atrans(props)
-      AM = reshape(A, props.dmid, props.dleft)
+      #AM = reshape(A, props.dmid, props.dleft)
+      AM = Base.ReshapedArray(A.parent, (props.dmid, props.dleft), ())
       tA = 'T'
     else
-      AM = reshape(A, props.dleft, props.dmid)
+      #AM = reshape(A, props.dleft, props.dmid)
+      AM = Base.ReshapedArray(A.parent, (props.dleft, props.dmid), ())
     end
   end
 
@@ -665,13 +668,16 @@ function _contract!(CT::DenseTensor{El, NC},
   if props.permuteB
     pB = NTuple{NB, Int}(props.PB)
     @strided Bp = permutedims(B, pB)
-    BM = reshape(Bp, props.dmid, props.dright)
+    #BM = reshape(Bp, props.dmid, props.dright)
+    BM = Base.ReshapedArray(Bp, (props.dmid, props.dright), ())
   else
     if Btrans(props)
-      BM = reshape(B, props.dright, props.dmid)
+      #BM = reshape(B, props.dright, props.dmid)
+      BM = Base.ReshapedArray(B.parent, (props.dright, props.dmid), ())
       tB = 'T'
     else
-      BM = reshape(B, props.dmid, props.dright)
+      #BM = reshape(B, props.dmid, props.dright)
+      BM = Base.ReshapedArray(B.parent, (props.dmid, props.dright), ())
     end
   end
 
@@ -679,16 +685,19 @@ function _contract!(CT::DenseTensor{El, NC},
   if props.permuteC
     # Need to copy here since we will be permuting
     # into C later
-    CM = reshape(copy(C), props.dleft, props.dright)
+    #CM = reshape(copy(C), props.dleft, props.dright)
+    CM = Base.ReshapedArray(C, (props.dleft, props.dright), ())
   else
     if Ctrans(props)
-      CM = reshape(C, props.dright, props.dleft)
+      #CM = reshape(C, props.dright, props.dleft)
+      CM = Base.ReshapedArray(C, (props.dright, props.dleft), ())
       (AM, BM) = (BM, AM)
       if tA == tB
         tA = tB = (tA == 'T' ? 'N' : 'T')
       end
     else
-      CM = reshape(C, props.dleft, props.dright)
+      #CM = reshape(C, props.dleft, props.dright)
+      CM = Base.ReshapedArray(C.parent, (props.dleft, props.dright), ())
     end
   end
 
@@ -696,7 +705,8 @@ function _contract!(CT::DenseTensor{El, NC},
 
   if props.permuteC
     pC = NTuple{NC, Int}(props.PC)
-    Cr = reshape(CM, props.newCrange...)
+    #Cr = reshape(CM, props.newCrange...)
+    Cr = Base.ReshapedArray(CM.parent, props.newCrange, ())
     # TODO: use invperm(pC) here?
     @strided C .= permutedims(Cr, pC)
   end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -649,17 +649,14 @@ function _contract!(CT::DenseTensor{El, NC},
   if props.permuteA
     pA = NTuple{NA, Int}(props.PA)
     @strided Ap = permutedims(A, pA)
-    #AM = reshape(Ap, props.dmid, props.dleft)
     AM = Base.ReshapedArray(Ap, (props.dmid, props.dleft), ())
     tA = 'T'
   else
     #A doesn't have to be permuted
     if Atrans(props)
-      #AM = reshape(A, props.dmid, props.dleft)
       AM = Base.ReshapedArray(A.parent, (props.dmid, props.dleft), ())
       tA = 'T'
     else
-      #AM = reshape(A, props.dleft, props.dmid)
       AM = Base.ReshapedArray(A.parent, (props.dleft, props.dmid), ())
     end
   end
@@ -668,15 +665,12 @@ function _contract!(CT::DenseTensor{El, NC},
   if props.permuteB
     pB = NTuple{NB, Int}(props.PB)
     @strided Bp = permutedims(B, pB)
-    #BM = reshape(Bp, props.dmid, props.dright)
     BM = Base.ReshapedArray(Bp, (props.dmid, props.dright), ())
   else
     if Btrans(props)
-      #BM = reshape(B, props.dright, props.dmid)
       BM = Base.ReshapedArray(B.parent, (props.dright, props.dmid), ())
       tB = 'T'
     else
-      #BM = reshape(B, props.dmid, props.dright)
       BM = Base.ReshapedArray(B.parent, (props.dmid, props.dright), ())
     end
   end
@@ -685,18 +679,15 @@ function _contract!(CT::DenseTensor{El, NC},
   if props.permuteC
     # Need to copy here since we will be permuting
     # into C later
-    #CM = reshape(copy(C), props.dleft, props.dright)
-    CM = Base.ReshapedArray(C, (props.dleft, props.dright), ())
+    CM = Base.ReshapedArray(copy(C), (props.dleft, props.dright), ())
   else
     if Ctrans(props)
-      #CM = reshape(C, props.dright, props.dleft)
-      CM = Base.ReshapedArray(C, (props.dright, props.dleft), ())
+      CM = Base.ReshapedArray(C.parent, (props.dright, props.dleft), ())
       (AM, BM) = (BM, AM)
       if tA == tB
         tA = tB = (tA == 'T' ? 'N' : 'T')
       end
     else
-      #CM = reshape(C, props.dleft, props.dright)
       CM = Base.ReshapedArray(C.parent, (props.dleft, props.dright), ())
     end
   end
@@ -705,12 +696,11 @@ function _contract!(CT::DenseTensor{El, NC},
 
   if props.permuteC
     pC = NTuple{NC, Int}(props.PC)
-    #Cr = reshape(CM, props.newCrange...)
     Cr = Base.ReshapedArray(CM.parent, props.newCrange, ())
     # TODO: use invperm(pC) here?
     @strided C .= permutedims(Cr, pC)
   end
-  return C
+  return CT
 end
 
 """


### PR DESCRIPTION
This implements #32, which speeds up very small tensor contractions a little bit by using `Base.ReshapedArray` instead of the `reshape` function in the Dense `contract!` function. It is only noticeable for contractions of matrices with dimensions of less than 20, i.e. running:
```julia
using ITensors

d = 5

a = randn(d, d)
b = randn(d, d)
c = randn(d, d)

i = Index(d)
A = itensor(a, i, i')
B = itensor(b, i', i'')
C = itensor(c, i, i'')

it = @belapsed $C .= $A .* $B
mm = @belapsed mul!($c, $a, $b)
@show it / mm
```
on the latest version of NDTensors gives:
```julia
it / mm = 3.7810970267495194
```
while on this branch it gives:
```julia
it / mm = 3.143474129969966
```
Nothing amazing, but also a good sign that something like that even shows up in the timings.