### PR TITLE
Tighter eltype(::Combiner) method: fix DataFrames.jl incompatibility

### DIFF
--- a/src/combiner.jl
+++ b/src/combiner.jl
@@ -19,7 +19,7 @@ blockcomb(C::Combiner) = C.comb
 
 Base.eltype(::Type{<:Combiner}) = Number
 
-Base.eltype(::StoreT) where {StoreT<:Combiner} = eltype(StoreT)
+Base.eltype(::Combiner) = eltype(Combiner)
 
 Base.promote_rule(::Type{<:Combiner},
                   StorageT::Type{<:Dense}) = StorageT


### PR DESCRIPTION
I was seeing a heisenbug-ish incompatibility with DataFrames.jl:
https://github.com/ITensor/ITensors.jl/issues/437. Unclear what was
going on: could be a bug (/ bad behavior) in DataFrames.jl or in
Julia's method-dispatch code (saw in v1.4.2). This change more tightly
specifies the method, working around the problem.