### PR TITLE
Make inds more generic

### DIFF
--- a/src/blocksparse/blockdims.jl
+++ b/src/blocksparse/blockdims.jl
@@ -11,6 +11,9 @@ An index for a BlockSparseTensor.
 """
 const BlockDim = Vector{Int}
 
+# Makes for generic code
+dim(d::BlockDim) = sum(d)
+
 """
 BlockDims{N}
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -135,45 +135,49 @@ Base.:*(x::Number,D::Dense) = D*x
 const DenseTensor{ElT,N,StoreT,IndsT} = Tensor{ElT,N,StoreT,IndsT} where {StoreT<:Dense}
 
 DenseTensor(::Type{ElT},
-            inds::Dims) where {ElT} = tensor(Dense(ElT,dim(inds)),inds)
+            inds) where {ElT} =
+  tensor(Dense(ElT,dim(inds)),inds)
 
+# Special convenience function for Int
+# dimensions
 DenseTensor(::Type{ElT},
-            inds::Int...) where {ElT} = DenseTensor(ElT,inds)
+            inds::Int...) where {ElT} =
+  DenseTensor(ElT, inds)
 
-DenseTensor(inds::Dims) = tensor(Dense(dim(inds)),inds)
+DenseTensor(inds) = tensor(Dense(dim(inds)), inds)
 
 DenseTensor(inds::Int...) = DenseTensor(inds)
 
 DenseTensor(::Type{ElT},
             ::UndefInitializer,
-            inds) where {ElT} = tensor(Dense(ElT,undef,dim(inds)),inds)
+            inds) where {ElT} =
+  tensor(Dense(ElT, undef, dim(inds)), inds)
 
 DenseTensor(::Type{ElT},
             ::UndefInitializer,
-            inds::Int...) where {ElT} = DenseTensor(ElT,undef,inds)
+            inds::Int...) where {ElT} =
+  DenseTensor(ElT, undef, inds)
 
 DenseTensor(::UndefInitializer,
-            inds::Dims) = tensor(Dense(undef,dim(inds)),inds)
+            inds) =
+  tensor(Dense(undef, dim(inds)), inds)
 
 DenseTensor(::UndefInitializer,
-            inds::Int...) = DenseTensor(undef,inds)
+            inds::Int...) =
+  DenseTensor(undef, inds)
 
 # For convenience, direct Tensor constructors default to Dense
-Tensor(::Type{ElT},inds::Dims) where {ElT} = DenseTensor(ElT,inds)
-Tensor(::Type{ElT},inds::Int...) where {ElT} = DenseTensor(ElT,inds...)
-Tensor(inds::Dims) = DenseTensor(inds)
-Tensor(inds::Int...) = DenseTensor(inds...)
+Tensor(::Type{ElT},
+       inds...) where {ElT} = DenseTensor(ElT, inds...)
+
+Tensor(inds...) = Tensor(Float64, inds...)
 
 Tensor(::Type{ElT},
        ::UndefInitializer,
-       inds::Dims) where {ElT} = DenseTensor(ElT,undef,inds)
-Tensor(::Type{ElT},
-       ::UndefInitializer,
-       inds::Int...) where {ElT} = DenseTensor(ElT,undef,inds...)
+       inds...) where {ElT} = DenseTensor(ElT, undef, inds...)
+
 Tensor(::UndefInitializer,
-       inds::Dims) = DenseTensor(undef,inds)
-Tensor(::UndefInitializer,
-       inds::Int...) = DenseTensor(undef,inds...)
+       inds...) = DenseTensor(undef, inds...)
 
 Tensor(A::Array{<:Number,N},
        inds::Dims{N}) where {N} = tensor(Dense(vec(A)),inds)
@@ -183,7 +187,7 @@ Tensor(A::Array{<:Number,N},
 #
 
 function randomDenseTensor(::Type{ElT},
-                           inds::Dims) where {ElT}
+                           inds) where {ElT}
   return tensor(randn(Dense{ElT},dim(inds)),inds)
 end
 
@@ -192,13 +196,13 @@ function randomDenseTensor(::Type{ElT},
   return randomDenseTensor(ElT, inds)
 end
 
-randomDenseTensor(inds::Dims) = randomDenseTensor(Float64, inds)
+randomDenseTensor(inds) = randomDenseTensor(Float64, inds)
 
 randomDenseTensor(inds::Int...) = randomDenseTensor(Float64, inds)
 
 function randomTensor(::Type{ElT},
-                      inds::Dims) where {ElT}
-  return randomDenseTensor(ElT,inds)
+                      inds) where {ElT}
+  return randomDenseTensor(ElT, inds)
 end
 
 function randomTensor(::Type{ElT},
@@ -206,7 +210,7 @@ function randomTensor(::Type{ElT},
   return randomDenseTensor(ElT, inds...)
 end
 
-randomTensor(inds::Dims) = randomDenseTensor(Float64, inds)
+randomTensor(inds) = randomDenseTensor(Float64, inds)
 
 randomTensor(inds::Int...) = randomDenseTensor(Float64, inds)
 

--- a/src/dims.jl
+++ b/src/dims.jl
@@ -8,6 +8,12 @@ export dense,
 # base Dims here
 dims(ds::Dims) = ds
 
+# Generic dims function
+dims(inds) = ntuple(i -> dim(inds[i]), Val(length(inds)))
+
+# Generic dim function
+dim(inds) = prod(dims(inds))
+
 dims(::Tuple{}) = ()
 
 dim(::Tuple{}) = 1

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -112,4 +112,37 @@ end
   @test norm(Tc) ≉ 0
 end
 
+@testset "Custom inds types" begin
+  struct MyInd
+    dim::Int
+  end
+  NDTensors.dim(i::MyInd) = i.dim
+
+  T = Tensor((MyInd(2), MyInd(3), MyInd(4)))
+  @test store(T) isa Dense
+  @test eltype(T) == Float64
+  @test norm(T) == 0
+  @test dims(T) == (2, 3, 4)
+  @test ndims(T) == 3
+  @test inds(T) == (MyInd(2), MyInd(3), MyInd(4))
+
+  T = randomTensor(ComplexF64, (MyInd(4), MyInd(3)))
+  @test store(T) isa Dense
+  @test eltype(T) == ComplexF64
+  @test norm(T) > 0
+  @test dims(T) == (4, 3)
+  @test ndims(T) == 2
+  @test inds(T) == (MyInd(4), MyInd(3))
+
+  T2 = 2 * T
+  @test eltype(T2) == ComplexF64
+  @test store(T2) isa Dense
+  @test norm(T2) > 0
+  @test norm(T2) / norm(T) ≈ 2
+  @test dims(T2) == (4, 3)
+  @test ndims(T2) == 2
+  @test inds(T2) == (MyInd(4), MyInd(3))
+
+end
+
 nothing

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -125,6 +125,9 @@ end
   @test dims(T) == (2, 3, 4)
   @test ndims(T) == 3
   @test inds(T) == (MyInd(2), MyInd(3), MyInd(4))
+  T[2, 1, 2] = 1.21
+  @test T[2, 1, 2] == 1.21
+  @test norm(T) == 1.21
 
   T = randomTensor(ComplexF64, (MyInd(4), MyInd(3)))
   @test store(T) isa Dense


### PR DESCRIPTION
This simplifies the overload requirement for custom inds to just overload `dim` for each element.

It also makes Dense Tensor constructors more generic (allows generic indices).