### PR TITLE
Make NDTensors compatible with Julia v1.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.3'
           - '1.4'
+          - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
 version = "0.1.13"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -14,7 +15,7 @@ Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 HDF5 = "0.12, 0.13"
 StaticArrays = "0.12"
 Strided = "0.3, 1"
-julia = "1.4"
+julia = "1.3"
 
 [extras]
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -1,5 +1,6 @@
 module NDTensors
 
+using Compat
 using Random
 using LinearAlgebra
 using StaticArrays


### PR DESCRIPTION
This uses [Compat.jl](https://github.com/JuliaLang/Compat.jl) to make NDTensors backwards compatible with Julia v1.3. There are a few small features we are using that were introduced in Julia v1.4, and Compat automatically defines them if someone is using Julia v1.3 and NDTensors.

Unfortunately we can't easily become compatible with older versions, mostly because the keyword argument `alg` in LinearAlgebra's `svd` function (for choosing the LAPACK svd algorithm) was introduced in Julia v1.3.