### PR TITLE
supporting generic types

### DIFF
--- a/test/dense.jl
+++ b/test/dense.jl
@@ -148,4 +148,25 @@ end
 
 end
 
+@testset "generic contraction" begin
+    # correctness of _gemm!
+    for alpha in [0.0, 1.0, 2.0]
+        for beta in [0.0, 1.0, 2.0]
+            for tA in ['N', 'T']
+                for tB in ['N', 'T']
+                    A = randn(4, 4)
+                    B = randn(4, 4)
+                    C = randn(4, 4)
+                    A = BigFloat.(A)
+                    B = BigFloat.(B)
+                    C2 = BigFloat.(C)
+                    NDTensors._gemm!(tA, tB, alpha, A, B, beta, C)
+                    NDTensors._gemm!(tA, tB, alpha, A, B, beta, C2)
+                    @test C ≈ C2
+                end
+            end
+        end
+    end
+end
+
 nothing


### PR DESCRIPTION
Supporting generic types in ITensor. Generic types can be used for the following purpose

* High precision tensor network contraction with Bigfloat or [DoubleFloat](https://github.com/JuliaMath/DoubleFloats.jl)

* [Tropical tensor network](https://arxiv.org/abs/2008.06888) contraction for solving combinatoric optimization problems.
Now the following example works

```julia
julia> using ITensors, TropicalNumbers

julia> it = ITensor(TropicalF64, [Index(2) for i=1:3]...)
ITensor ord=3 (dim=2|id=852) (dim=2|id=30) (dim=2|id=299)
NDTensors.Dense{Tropical{Float64},Array{Tropical{Float64},1}}

julia> it * it
ITensor ord=0
NDTensors.Dense{Tropical{Float64},Array{Tropical{Float64},1}}
```