### PR TITLE
Used LAPACK gesdd by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.1.15"
+version = "0.1.16"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/blocksparse/linearalgebra.jl
+++ b/src/blocksparse/linearalgebra.jl
@@ -32,7 +32,7 @@ computed from the dense svds of seperate blocks.
 """
 function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
                            kwargs...) where {ElT}
-  alg::String = get(kwargs, :alg, "recursive")
+  alg::String = get(kwargs, :alg, "divide_and_conquer")
 
   truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
 

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -59,6 +59,15 @@ function entropy(s::Spectrum)
   return S
 end
 
+function svd_catch_error(A; kwargs...)
+  USV = try
+    svd(A; kwargs...)
+  catch
+    return nothing
+  end
+  return USV
+end
+
 """
     svd(T::DenseTensor{<:Number,2}; kwargs...)
 
@@ -100,17 +109,46 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
   use_relative_cutoff::Bool = get(kwargs,
                                   :use_relative_cutoff,
                                   use_relative_cutoff)
-  alg::String = get(kwargs, :alg, "recursive")
+  alg::String = get(kwargs, :alg, "divide_and_conquer")
 
   if alg == "divide_and_conquer"
-    MU,MS,MV = svd(matrix(T); alg = LinearAlgebra.DivideAndConquer())
+    MUSV = svd_catch_error(matrix(T); alg = LinearAlgebra.DivideAndConquer())
   elseif alg == "qr_iteration"
-    MU,MS,MV = svd(matrix(T); alg = LinearAlgebra.QRIteration())
+    MUSV = svd_catch_error(matrix(T); alg = LinearAlgebra.QRIteration())
   elseif alg == "recursive"
-    MU,MS,MV = svd_recursive(matrix(T))
+    MUSV = svd_recursive(matrix(T))
   else
     error("svd algorithm $alg is not currently supported. Please see the documentation for currently supported algorithms.")
   end
+  if isnothing(MUSV)
+    lapack_svd_error =
+      "The SVD algorithm `\"$alg\"` has thrown an error,\n" *
+      "likely because of a convergance failure. You can try\n" *
+      "other SVD algorithms that may converge better using the\n" *
+      "`alg` keyword argument:\n\n" *
+      " - \"divide_and_conquer\" is a divide-and-conquer algorithm\n" *
+      "   (LAPACK's `gesdd`). It is fast, but may lead to some innacurate\n" *
+      "   singular values for very ill-conditioned matrices.\n" *
+      "   It also may sometimes fail to converge, leading to errors\n" *
+      "   (in which case `\"qr_iteration\"` or `\"recursive\"` can be tried).\n\n" *
+      " - `\"qr_iteration\"` (LAPACK's `gesvd`) is typically slower \n" *
+      "   than \"divide_and_conquer\", especially for large matrices,\n" *
+      "   but is more accurate for very ill-conditioned matrices \n" *
+      "   compared to `\"divide_and_conquer\"`.\n\n" *
+      " - `\"recursive\"` is ITensor's custom SVD algorithm. It is very\n" *
+      "   reliable, but may be slow if high precision is needed.\n" *
+      "   To get an `svd` of a matrix `A`, an eigendecomposition of\n" *
+      "   ``A^{\\dagger} A`` is used to compute `U` and then a `qr` of\n" *
+      "   ``A^{\\dagger} U`` is used to compute `V`. This is performed\n" *
+      "   recursively to compute small singular values.\n\n" *
+      "Returning `nothing`. For an output `F = svd(A, ...)` you can check if\n" *
+      "`isnothing(F)` in your code and try a different algorithm.\n\n" *
+      "To suppress this message in the future, you can wrap the `svd` call in the\n" *
+      "`@suppress` macro from the `Suppressor` package.\n"
+    println(lapack_svd_error)
+    return nothing
+  end
+  MU, MS, MV = MUSV
   conj!(MV)
 
   P = MS .^ 2


### PR DESCRIPTION
This makes the svd use LAPACK's gesdd by default. It also catches any errors from gesdd, and if there are errors it returns `nothing` and prints out an explanation about how to try other SVD algorithms.