### PR TITLE
TBLIS backend support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+This is an example of using TBLIS as a contraction backend.
+
+First install TBLIS.jl: https://github.com/mtfishman/TBLIS.jl
+
+TBLIS is enabled by the command `using TBLIS`. Once it is enabled, it can be
+disabled with the command `disable_tblis!()`, and enabled again with the command
+`enable_tblis!()`. You can then set the number of threads with `TBLIS.set_num_threads(n)`.
+
+Currently only tensor contractions involving real elements (Float32 and Float64)
+get dispatched to TBLIS, since the complex number support of TBLIS is limited (https://github.com/devinamatthews/tblis/issues/18).
+

--- a/examples/tblis.jl
+++ b/examples/tblis.jl
@@ -1,0 +1,61 @@
+using LinearAlgebra
+using NDTensors
+using TBLIS
+
+let
+  d = 25
+
+  nthreads = 4
+
+  A = randomTensor(d, d, d, d)
+  B = randomTensor(d, d, d, d)
+  C_blas = randomTensor(d, d, d, d)
+
+  labelsA = (1, -1, 2, -2)
+  labelsB = (-2, 4, 3, -1)
+  labelsC = (1, 2, 3, 4)
+
+  println("Contracting (d x d x d x d) tensors A * B -> C, d = ", d)
+  @show labelsA
+  @show labelsB
+  @show labelsC
+
+  #
+  # Use BLAS
+  #
+
+  disable_tblis!()
+  BLAS.set_num_threads(nthreads)
+
+  println()
+  println("Using BLAS with $nthreads threads")
+
+  time_blas = @belapsed NDTensors.contract!($C_blas, $labelsC, $A, $labelsA, $B, $labelsB) samples = 100
+
+  println()
+  println("Time (BLAS) = ", time_blas, " seconds")
+
+  #
+  # Use TBLIS
+  #
+
+  enable_tblis!()
+  TBLIS.set_num_threads(nthreads)
+
+  println()
+  println("Using TBLIS with $(TBLIS.get_num_threads()) threads")
+
+  C_tblis = randomTensor(d, d, d, d)
+
+  time_tblis = @belapsed NDTensors.contract!($C_tblis, $labelsC, $A, $labelsA, $B, $labelsB) samples = 100
+
+  println()
+  println("Time (TBLIS) = ", time_tblis, " seconds")
+
+  println()
+  @show C_blas ≈ C_tblis
+
+  println()
+  println("Time (TBLIS) / Time (BLAS) = ", time_tblis / time_blas)
+end
+

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -5,6 +5,7 @@ using Random
 using LinearAlgebra
 using StaticArrays
 using HDF5
+using Requires
 using Strided
 
 #####################################
@@ -43,5 +44,12 @@ include("blocksparse/linearalgebra.jl")
 # Empty
 #
 include("empty.jl")
+
+#####################################
+# Optional TBLIS contraction backend
+#
+function __init__()
+  @require TBLIS="48530278-0828-4a49-9772-0f3830dfa1e9" include("tblis.jl")
+end
 
 end # module NDTensors

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -48,8 +48,25 @@ include("empty.jl")
 #####################################
 # Optional TBLIS contraction backend
 #
+const _use_tblis = Ref(false)
+
+use_tblis() = _use_tblis[]
+
+function enable_tblis!()
+  _use_tblis[] = true
+  return nothing
+end
+
+function disable_tblis!()
+  _use_tblis[] = false
+  return nothing
+end
+
 function __init__()
-  @require TBLIS="48530278-0828-4a49-9772-0f3830dfa1e9" include("tblis.jl")
+  @require TBLIS="48530278-0828-4a49-9772-0f3830dfa1e9" begin
+    enable_tblis!()
+    include("tblis.jl")
+  end
 end
 
 end # module NDTensors

--- a/src/blocksparse/blocksparsetensor.jl
+++ b/src/blocksparse/blocksparsetensor.jl
@@ -852,25 +852,26 @@ function contract(T1::BlockSparseTensor{<:Any,N1},
   return R
 end
 
-function contract!(R::BlockSparseTensor{<:Number,NR},
+function contract!(R::BlockSparseTensor{ElR, NR},
                    labelsR,
-                   T1::BlockSparseTensor{<:Number,N1},
+                   T1::BlockSparseTensor{ElT1, N1},
                    labelsT1,
-                   T2::BlockSparseTensor{<:Number,N2},
+                   T2::BlockSparseTensor{ElT2, N2},
                    labelsT2,
-                   contraction_plan) where {N1,N2,NR}
+                   contraction_plan) where {ElR, ElT1, ElT2,
+                                            N1, N2, NR}
   already_written_to = fill(false,nnzblocks(R))
   # In R .= α .* (T1 * T2) .+ β .* R
-  α = 1
+  α = one(ElR)
   for (pos1,pos2,posR) in contraction_plan
     blockT1 = blockview(T1,pos1)
     blockT2 = blockview(T2,pos2)
     blockR = blockview(R,posR)
-    β = 1
+    β = one(ElR)
     if !already_written_to[posR]
       already_written_to[posR] = true
       # Overwrite the block of R
-      β = 0
+      β = zero(ElR)
     end
     contract!(blockR,labelsR,
               blockT1,labelsT1,

--- a/src/blocksparse/linearalgebra.jl
+++ b/src/blocksparse/linearalgebra.jl
@@ -46,7 +46,11 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
   for n in 1:nnzblocks(T)
     b = nzblock(T, n)
     blockT = blockview(T, n)
-    Ub, Sb, Vb = svd(blockT; alg = alg)
+    USVb = svd(blockT; alg = alg)
+    if isnothing(USVb)
+      return nothing
+    end
+    Ub, Sb, Vb = USVb
     Us[n] = Ub
     Ss[n] = Sb
     Vs[n] = Vb

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,16 +1,21 @@
-export addblock!!,
-       setindex,
-       setindex!!,
+export 
+# NDTensors.jl
+  disable_tblis!,
+  enable_tblis!,
+
+  addblock!!,
+  setindex,
+  setindex!!,
 
 # blocksparse/blocksparsetensor.jl
-       randomBlockSparseTensor,
+  randomBlockSparseTensor,
 
 # dense.jl
-       randomTensor,
-       randomDenseTensor,
+  randomTensor,
+  randomDenseTensor,
 
 # empty.jl
-       Empty,
-       EmptyTensor,
-       EmptyBlockSparseTensor
+  Empty,
+  EmptyTensor,
+  EmptyBlockSparseTensor
 

--- a/src/tblis.jl
+++ b/src/tblis.jl
@@ -1,0 +1,42 @@
+
+function contract!(R::DenseTensor{ElT},
+                   labelsR,
+                   T1::DenseTensor{ElT},
+                   labelsT1,
+                   T2::DenseTensor{ElT},
+                   labelsT2,
+                   α::ElT = one(ElT),
+                   β::ElT = zero(ElT)) where {ElT <: LinearAlgebra.BlasReal}
+  # TBLIS Tensors
+  R_tblis = TBLIS.TTensor{ElT}(array(R), β)
+  T1_tblis = TBLIS.TTensor{ElT}(array(T1), α)
+  T2_tblis = TBLIS.TTensor{ElT}(array(T2))
+
+  function label_to_char(label)
+    # Start at 'a'
+    char_start = Char(96)
+    if label < 0
+      # Start at 'z'
+      char_start = Char(123)
+    end
+    return char_start + label
+  end
+
+  function labels_to_tblis(labels)
+    if isempty(labels)
+      return ""
+    end
+    str = prod(label_to_char.(labels))
+    return str
+  end
+
+  labelsT1_tblis = labels_to_tblis(labelsT1)
+  labelsT2_tblis = labels_to_tblis(labelsT2)
+  labelsR_tblis = labels_to_tblis(labelsR)
+
+  TBLIS.mul!(R_tblis, T1_tblis, T2_tblis,
+             labelsT1_tblis, labelsT2_tblis, labelsR_tblis)
+
+  return R
+end
+

--- a/src/tblis.jl
+++ b/src/tblis.jl
@@ -1,12 +1,13 @@
 
-function contract!(R::DenseTensor{ElT},
+function contract!(::Val{:TBLIS},
+                   R::DenseTensor{ElT},
                    labelsR,
                    T1::DenseTensor{ElT},
                    labelsT1,
                    T2::DenseTensor{ElT},
                    labelsT2,
-                   α::ElT = one(ElT),
-                   β::ElT = zero(ElT)) where {ElT <: LinearAlgebra.BlasReal}
+                   α::ElT,
+                   β::ElT) where {ElT <: LinearAlgebra.BlasReal}
   # TBLIS Tensors
   R_tblis = TBLIS.TTensor{ElT}(array(R), β)
   T1_tblis = TBLIS.TTensor{ElT}(array(T1), α)

--- a/test/blocksparse.jl
+++ b/test/blocksparse.jl
@@ -288,7 +288,7 @@ using LinearAlgebra
       A = BlockSparseTensor([(1,2),(2,3)],[5,6],[2,3,4])
       randn!(A)
       U,S,V = svd(A)
-      @test isapprox(norm(array(U)*array(S)*array(V)'-array(A)),0.0; atol=1e-14)
+      @test isapprox(norm(array(U)*array(S)*array(V)'-array(A)),0.0; atol=1e-13)
     end
   end
 


### PR DESCRIPTION
This adds support for using TBLIS as a backend for (real) tensor contractions. Here is the interface:
```julia
using BenchmarkTools
using LinearAlgebra
using NDTensors
using TBLIS

d = 25

# Set the TBLIS and BLAS threads
nthreads = 4
TBLIS.set_num_threads(nthreads)
BLAS.set_num_threads(nthreads)

A = randomTensor(d, d, d, d);
B = randomTensor(d, d, d, d);
C = randomTensor(d, d, d, d);

labelsA = (1, -1, 2, -2)
labelsB = (-2, 4, 3, -1)
labelsC = (1, 2, 3, 4)

# Use TBLIS (on by default from `using TBLIS` command)
println("Benchmark TBLIS")
C_tblis = copy(C);
@btime NDTensors.contract!($C_tblis, $labelsC, $A, $labelsA, $B, $labelsB) samples = 100;

# Use BLAS
println("Benchmark BLAS")
disable_tblis!()
C_blas = copy(C);
@btime NDTensors.contract!($C_blas, $labelsC, $A, $labelsA, $B, $labelsB) samples = 100;

println()
@show C_blas ≈ C_tblis

# Can enable TBLIS again
enable_tblis!()
```
This outputs something like the following on my laptop:
```julia
julia> include("/tmp/tblis.jl")
nt: 6
Benchmark TBLIS
  2.639 ms (28 allocations: 1.89 KiB)
Benchmark BLAS
  3.589 ms (38 allocations: 8.94 MiB)

C_blas ≈ C_tblis = true
```
so it is about 25% faster and uses a lot less memory.

In order to use it, you first have to install TBLIS.jl (and right now, to get commands like `TBLIS.set_num_threads(4)`, you need to use my fork: https://github.com/mtfishman/TBLIS.jl).

Note that it is only limited to real contractions right now, since the TBLIS support for complex tensors is currently limited (https://github.com/devinamatthews/tblis/issues/18). I've also found that it doesn't help with the DMRG calculations I have tried (specifically, it doesn't give a speedup, and sometimes is even a bit slower). My guess is that many DMRG contractions can map directly to BLAS calls without permutations, and in those cases TBLIS is slower than MKL. It may also have to do with the tensor dimensions involved.