### PR TITLE
Some low level optimizations

### DIFF
--- a/src/blocksparse/linearalgebra.jl
+++ b/src/blocksparse/linearalgebra.jl
@@ -163,6 +163,14 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
     blockS = nzblocksS[n]
     blockV = nzblocksV[n]
 
+    if VERSION < v"1.5"
+      # In v1.3 and v1.4 of Julia, Ub has
+      # a very complicated view wrapper that
+      # can't be handled efficiently
+      Ub = copy(Ub)
+      Vb = copy(Vb)
+    end
+
     blockview(U, blockU) .= Ub
     blockviewS = blockview(S, blockS)
     for i in 1:diaglength(Sb)

--- a/src/blocksparse/linearalgebra.jl
+++ b/src/blocksparse/linearalgebra.jl
@@ -36,9 +36,9 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
 
   truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
 
-  Us = Vector{BlockSparseMatrix{ElT}}(undef, nnzblocks(T))
-  Ss = Vector{DiagBlockSparseMatrix{real(ElT)}}(undef, nnzblocks(T))
-  Vs = Vector{BlockSparseMatrix{ElT}}(undef, nnzblocks(T))
+  Us = Vector{DenseTensor{ElT, 2}}(undef, nnzblocks(T))
+  Ss = Vector{DiagTensor{real(ElT), 2}}(undef, nnzblocks(T))
+  Vs = Vector{DenseTensor{ElT, 2}}(undef, nnzblocks(T))
 
   # Sorted eigenvalues
   d = Vector{real(ElT)}()
@@ -79,9 +79,9 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
       else
         Strunc = tensor(Diag(store(Ss[n])[1:blockdim]),
                         (blockdim,blockdim))
-        Us[n] = copy(Us[n][1:dim(Us[n],1),1:blockdim])
+        Us[n] = Us[n][1:dim(Us[n],1),1:blockdim]
         Ss[n] = Strunc
-        Vs[n] = copy(Vs[n][1:dim(Vs[n],1),1:blockdim])
+        Vs[n] = Vs[n][1:dim(Vs[n],1),1:blockdim]
       end
     end
     deleteat!(Us,dropblocks)
@@ -168,6 +168,7 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
     for i in 1:diaglength(Sb)
       setdiagindex!(blockviewS, getdiagindex(Sb, i), i)
     end
+
     blockview(V, blockV) .= Vb
   end
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -354,9 +354,12 @@ function Base.reshape(T::DenseTensor, dims::Int...)
   return tensor(store(T), tuple(dims...))
 end
 
+Base.convert(::Type{Array}, T::DenseTensor) =
+  reshape(data(store(T)), dims(inds(T)))
+
 # Create an Array that is a view of the Dense Tensor
 # Useful for using Base Array functions
-array(T::DenseTensor) = reshape(data(store(T)),dims(inds(T)))
+array(T::DenseTensor) = convert(Array, T)
 
 function Base.Array{ElT,N}(T::DenseTensor{ElT,N}) where {ElT,N}
   return copy(array(T))

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -366,6 +366,14 @@ function Base.Array(T::DenseTensor{ElT,N}) where {ElT,N}
   return Array{ElT,N}(T)
 end
 
+function Base.copyto!(R::DenseTensor{<:Number, N},
+                      T::DenseTensor{<:Number, N}) where {N}
+  RA = array(R)
+  TA = array(T)
+  @strided RA .= TA
+  return R
+end
+
 # TODO: call permutedims!(R,T,perm,(r,t)->t)?
 function Base.permutedims!(R::DenseTensor{<:Number,N},
                            T::DenseTensor{<:Number,N},

--- a/src/diag.jl
+++ b/src/diag.jl
@@ -134,6 +134,9 @@ function Base.convert(::Type{<:DenseTensor{ElT,N}}, T::DiagTensor{ElT,N}) where 
   return dense(T)
 end
 
+Base.convert(::Type{Diagonal}, D::DiagTensor{<:Number, 2}) =
+  Diagonal(data(D))
+
 # These are rules for determining the output of a pairwise contraction of NDTensors
 # (given the indices of the output tensors)
 function contraction_output_type(TensorT1::Type{<:DiagTensor},


### PR DESCRIPTION
This makes two optimizations:

1. Speed up dense Tensor `copyto!` by calling out to Strided.jl (the one in Julia is generally fast, but there was a case that was showing up in block sparse SVD where a complicated Tensor view wasn't being handled well by generic Julia code).
2. Convert the most generic Diag-Dense contraction to Dense-Dense contraction (Diag-Dense contraction is currently slow, the goal would be to speed it up eventually but I have seen it slow down code so this is the easiest way to go in the meantime).