### PR TITLE
Microoptimizations of contraction logic code

### DIFF
--- a/src/blocksparse/blocksparsetensor.jl
+++ b/src/blocksparse/blocksparsetensor.jl
@@ -646,8 +646,8 @@ function uncombine(T::BlockSparseTensor{<:Number,NT},
       #copyto!(Rb,Tb)
  
       Rbₐ = convert(Array, Rb)
-      Rbₐ = reshape(Rbₐ, size(Tb))
-      @strided Rbₐ .= Tb
+      Rbₐᵣ = Base.ReshapedArray(parent(Rbₐ), size(Tb), ())
+      @strided Rbₐᵣ .= Tb
     end
   end
   return R

--- a/src/contraction_logic.jl
+++ b/src/contraction_logic.jl
@@ -436,6 +436,7 @@ function compute_contraction_properties!(props::ContractionProperties{NA,NB,NC},
     BtoC = props.BtoC
     ai = props.ai
     bi = props.bi
+    ci = props.ci
     Bcstart = props.Bcstart
     Bustart = props.Bustart
 
@@ -509,24 +510,34 @@ function compute_contraction_properties!(props::ContractionProperties{NA,NB,NC},
   end
 
   if props.permuteA || props.permuteB
+    AtoC = props.AtoC
+    BtoC = props.BtoC
+    PC = props.PC
+
     #Recompute props.PC
     c = 1
     #TODO: check this is correct for 1-indexing
     for i = 1:NA
-      if !contractedA(props,i)
-        props.PC[props.AtoC[i]] = c
+      AtoC_i = AtoC[i]
+      if !(AtoC_i < 1)
+        #props.PC[props.AtoC[i]] = c
+        PC = Base.setindex(PC, c, AtoC_i)
         c += 1
       end
     end
     #TODO: check this is correct for 1-indexing
     for j = 1:NB
-      if !contractedB(props,j)
-        props.PC[props.BtoC[j]] = c
+      BtoC_j = BtoC[j]
+      if !(BtoC_j < 1)
+        #props.PC[props.BtoC[j]] = c
+        PC = Base.setindex(PC, c, BtoC_j)
         c += 1
       end
     end
+    props.PC = PC
+
     props.ctrans = false
-    if(is_trivial_permutation(props.PC))
+    if(is_trivial_permutation(PC))
       props.permuteC = false
     else
       props.permuteC = true
@@ -544,10 +555,12 @@ function compute_contraction_properties!(props::ContractionProperties{NA,NB,NC},
   if props.permuteC
     Rb = MVector{NC,Int}(undef) #Int[]
     k = 1
+    AtoC = props.AtoC
+    BtoC = props.BtoC
     if !props.permuteA
       #TODO: check this is correct for 1-indexing
       for i = 1:NA
-        if !contractedA(props,i)
+        if !(AtoC[i] < 1)
           #push!(Rb,size(A,i))
           Rb[k] = size(A, i)
           k = k + 1
@@ -556,7 +569,7 @@ function compute_contraction_properties!(props::ContractionProperties{NA,NB,NC},
     else
       #TODO: check this is correct for 1-indexing
       for i = 1:NA
-        if !contractedA(props,i)
+        if !(AtoC[i] < 1)
           #push!(Rb,size(props.newArange,i))
           Rb[k] = props.newArange[i]
           k = k + 1
@@ -566,7 +579,7 @@ function compute_contraction_properties!(props::ContractionProperties{NA,NB,NC},
     if !props.permuteB
       #TODO: check this is correct for 1-indexing
       for j = 1:NB
-        if !contractedB(props,j)
+        if !(BtoC[j] < 1)
           #push!(Rb,size(B,j))
           Rb[k] = size(B, j)
           k = k + 1
@@ -575,7 +588,7 @@ function compute_contraction_properties!(props::ContractionProperties{NA,NB,NC},
     else
       #TODO: check this is correct for 1-indexing
       for j = 1:NB
-        if !contractedB(props,j)
+        if !(BtoC[j] < 1)
           #push!(Rb,size(props.newBrange,j))
           Rb[k] = props.newBrange[j]
           k = k + 1


### PR DESCRIPTION
This adds some microoptimizations to the contraction logic code. The main strategy is minimizing the number of `getfield` calls to the `ContractionProperties` mutable struct by avoiding things like `props.Acstart` in loops. Here is a benchmark:
```julia
using BenchmarkTools
using ITensors

N = 6 
d = 1 
i = Index(QN(0, 2) => d, QN(1, 2) => d)
is = IndexSet(n -> settags(i, "i$n"), N)
A = randomITensor(is'..., dag(is)...)
B = randomITensor(is'..., dag(is)...)

@btime $A' * $B samples = 5
```
on this branch gives:
```julia
julia> include("time.jl");
  115.340 ms (868058 allocations: 138.49 MiB)
```
while on master:
```julia
julia> include("time.jl");
  170.253 ms (1261274 allocations: 141.49 MiB)
```
This case is pretty extreme since it involves contracting many very small blocks, so the contraction logic really dominates.

Most of the rest of the time spent in this example is block sparse logic like creating the block-offset list for the output tensor.