### PR TITLE
Block sparse operations

### DIFF
--- a/src/blocksparse/block.jl
+++ b/src/blocksparse/block.jl
@@ -95,6 +95,13 @@ insertafter(b::Block, val, pos) =
 getindices(b::Block, I) = getindices(Tuple(b), I)
 
 #
+# checkbounds
+#
+
+# XXX: define this properly
+Base.checkbounds(::Tensor, ::Block) = nothing
+
+#
 # Hashing
 #
 

--- a/src/blocksparse/block.jl
+++ b/src/blocksparse/block.jl
@@ -158,3 +158,11 @@ hash(b::Block, h::UInt) = h + hash(b)
 #  return h
 #end
 
+#
+# Printing for Block type
+#
+
+show(io::IO, mime::MIME"text/plain", b::Block) = print(io, "Block$(Int.(Tuple(b)))")
+
+show(io::IO, b::Block) = show(io, MIME("text/plain"), b)
+

--- a/src/blocksparse/blockoffsets.jl
+++ b/src/blocksparse/blockoffsets.jl
@@ -19,8 +19,7 @@ nzblock(block::Block) = block
 
 # Get the offset if the nth block in the block-offsets
 # list
-offset(bofs::BlockOffsets, n::Int) =
-  offset(bofs[n])
+offset(bofs::BlockOffsets, n) = offset(bofs[n])
 
 nnzblocks(bofs::BlockOffsets) = length(bofs)
 nnzblocks(bs::Blocks) = length(bs)

--- a/src/blocksparse/blocksparsetensor.jl
+++ b/src/blocksparse/blocksparsetensor.jl
@@ -987,7 +987,7 @@ function show(io::IO,
   summary(io, T)
   for (n, block) in enumerate(keys(blockoffsets(T)))
     blockdimsT = blockdims(T,block)
-    println(io, "Block: ", block)
+    println(io, block)
     println(io, " [", _range2string(blockstart(T,block),blockend(T,block)),"]")
     print_tensor(io, blockview(T,block))
     n < nnzblocks(T) && print(io, "\n\n")

--- a/src/blocksparse/blocksparsetensor.jl
+++ b/src/blocksparse/blocksparsetensor.jl
@@ -238,6 +238,21 @@ insertblock!(T::BlockSparseTensor, block) = insertblock!(T, Block(block))
   return T
 end
 
+hasblock(T::Tensor, block::Block) = isassigned(blockoffsets(T), block)
+
+@propagate_inbounds function setindex!(T::BlockSparseTensor{ElT,N},
+                                       val,
+                                       b::Block{N}) where {ElT,N}
+  if !hasblock(T, b)
+    insertblock!(T, b)
+  end
+  Tb = T[b]
+  Tb .= val
+  return T
+end
+
+getindex(T::BlockSparseTensor, block::Block) = blockview(T, block)
+
 blockview(T::BlockSparseTensor, block::Block) =
   blockview(T, BlockOffset(block, offset(T, block)))
 

--- a/src/blocksparse/diagblocksparse.jl
+++ b/src/blocksparse/diagblocksparse.jl
@@ -568,7 +568,7 @@ function Base.show(io::IO,
   summary(io,T)
   for (n, (block, _)) in enumerate(diagblockoffsets(T))
     blockdimsT = blockdims(T,block)
-    println(io,"Block: ",block)
+    println(io, block)
     println(io," [",_range2string(blockstart(T,block),blockend(T,block)),"]")
     print_tensor(io,blockview(T,block))
     n < nnzblocks(T) && print(io, "\n\n")

--- a/src/empty.jl
+++ b/src/empty.jl
@@ -96,23 +96,14 @@ end
 insertblock!!(T::EmptyTensor{<: Number, N}, block) where {N} =
   insertblock(T, block)
 
-Base.@propagate_inbounds function Base.setindex(T::EmptyTensor{<: Number, N},
-                                                x::Number,
-                                                I::Vararg{Int, N}) where {N}
+@propagate_inbounds function setindex(T::EmptyTensor{<: Number, N},
+                                      x, I...) where {N}
   R = zeros(T)
   R[I...] = x
   return R
 end
 
-function Base.setindex(T::EmptyTensor{<: Number, Any},
-                                      x::Number,
-                                      I::Int...)
-  error("Setting element of EmptyTensor with Any number of dimensions not defined")
-end
-
-setindex!!(T::EmptyTensor,
-           x::Number,
-           I::Int...) = setindex(T, x, I...)
+setindex!!(T::EmptyTensor, x, I...) = setindex(T, x, I...)
 
 function Base.show(io::IO,
                    mime::MIME"text/plain",

--- a/src/tensorstorage.jl
+++ b/src/tensorstorage.jl
@@ -76,6 +76,5 @@ eachnzblock(T::TensorStorage) = eachnzblock(blockoffsets(T))
 nnzblocks(S::TensorStorage) = length(blockoffsets(S))
 nnz(S::TensorStorage) = length(S)
 
-offset(S::TensorStorage,
-       block) = offset(blockoffsets(S), block)
+offset(S::TensorStorage, block) = offset(blockoffsets(S), block)
 

--- a/test/blocksparse.jl
+++ b/test/blocksparse.jl
@@ -22,10 +22,6 @@ using LinearAlgebra
   @test isblocknz(A,(1,2))
   @test !isblocknz(A,(1,1))
   @test !isblocknz(A,(2,2))
-  @test findblock(A,(2,1))==1
-  @test findblock(A,(1,2))==2
-  @test isnothing(findblock(A,(1,1)))
-  @test isnothing(findblock(A,(2,2)))
 
   # Test different ways of getting nnz
   @test nnz(blockoffsets(A),inds(A)) == nnz(A)
@@ -217,20 +213,20 @@ using LinearAlgebra
   end
 
   @testset "reshape" begin
-    indsA = ([2,3],[4,5])
-    locsA = [(2,1),(1,2)]
-    A = BlockSparseTensor(locsA,indsA...)
+    indsA = ([2,3], [4,5])
+    locsA = [(2,1), (1,2)]
+    A = BlockSparseTensor(locsA, indsA...)
     randn!(A)
 
     indsB = ([8,12,10,15],)
-    B = reshape(A,indsB)
+    B = reshape(A, indsB)
 
-    @test nnzblocks(A)==nnzblocks(B)
-    @test nnz(A)==nnz(B)
-    for i in 1:nnzblocks(B)
-      blockA = blockview(A,i)
-      blockB = blockview(B,i)
-      @test reshape(blockA,size(blockB))==blockB
+    @test nnzblocks(A) == nnzblocks(B)
+    @test nnz(A) == nnz(B)
+    for (bA, bB) in zip(eachnzblock(A), eachnzblock(B))
+      blockA = blockview(A, bA)
+      blockB = blockview(B, bB)
+      @test reshape(blockA, size(blockB)) == blockB
     end
   end
 
@@ -247,9 +243,9 @@ using LinearAlgebra
 		
     Ap = permutedims(A,(3,2,1))
 
-    for i in 1:nnzblocks(A)
-      blockAp = blockview(Ap,i)
-      blockB = blockview(B,i)
+    for (bAp, bB) in zip(eachnzblock(Ap), eachnzblock(B))
+      blockAp = blockview(Ap, bAp)
+      blockB = blockview(B, bB)
       @test reshape(blockAp,size(blockB))==blockB
     end
   end
@@ -302,9 +298,9 @@ using LinearAlgebra
     A = BlockSparseTensor(ComplexF64,[(1,1),(2,2)],([2,2],[2,2]))
     randn!(A)
     Ah = BlockSparseTensor(ComplexF64,undef,[(1,1),(2,2)],([2,2],[2,2]))
-    for n in 1:nnzblocks(A)
-      b= blockview(A,n)
-      blockview(Ah,n) .= b + b'
+    for bA in eachnzblock(A)
+      b = blockview(A, bA)
+      blockview(Ah, bA) .= b + b'
     end
     expTh = exp(Hermitian(Ah))
     @test array(expTh) ≈ exp(Hermitian(array(Ah))) rtol = 1e-13


### PR DESCRIPTION
This PR adds various block sparse operations such as indexing with `Block` types, which are useful for the `dropzeros` and `splitblocks` functionality introduced here: https://github.com/ITensor/ITensors.jl/pull/540.

`dropzeros` and `splitblocks` should probably be moved to NDTensors.