### PR TITLE
Fix bug in scalar contract with mixed element types

### DIFF
--- a/test/dense.jl
+++ b/test/dense.jl
@@ -169,4 +169,28 @@ end
     end
 end
 
+@testset "Contraction with size 1 block and NaN" begin
+  @testset "No permutation" begin
+    R = Tensor(ComplexF64, 2, 2, 1)
+    fill!(R, NaN)
+    @test any(isnan, R)
+    T1 = randomTensor(2, 2, 1)
+    T2 = randomTensor(ComplexF64, 1, 1)
+    NDTensors.contract!(R, (1, 2, 3), T1, (1, 2, -1), T2, (-1, 1))
+    @test !any(isnan, R)
+    @test convert(Array, R) ≈ convert(Array, T1) * T2[1]
+  end
+
+  @testset "Permutation" begin
+    R = Tensor(ComplexF64, 2, 2, 1)
+    fill!(R, NaN)
+    @test any(isnan, R)
+    T1 = randomTensor(2, 2, 1)
+    T2 = randomTensor(ComplexF64, 1, 1)
+    NDTensors.contract!(R, (2, 1, 3), T1, (1, 2, -1), T2, (-1, 1))
+    @test !any(isnan, R)
+    @test convert(Array, R) ≈ permutedims(convert(Array, T1), (2, 1, 3)) * T2[1]
+  end
+end
+
 nothing


### PR DESCRIPTION
This is an extremely particular bug introduced by the recent optimizations to contractions involving scalar-like tensors. It affects contractions involving a scalar tensor with a non-scalar tensor, where the tensors have different element types. The cause of the bug is that we are using `BLAS.axpby!`, but in the mixed element type case, it gets dispatched to a generic Julia fallback. However, the generic Julia fallback and BLAS version handle `NaN` different with `beta = 0`. When `beta = 0`, BLAS overwrites the modified array with zeros, but Julia forwards the `NaN`. This is fixed by creating our own dispatch path for the mixed element type case.