### PR TITLE
Threaded blocksparse

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,8 +3,8 @@ This is an example of using TBLIS as a contraction backend.
 First install TBLIS.jl: https://github.com/mtfishman/TBLIS.jl
 
 TBLIS is enabled by the command `using TBLIS`. Once it is enabled, it can be
-disabled with the command `disable_tblis!()`, and enabled again with the command
-`enable_tblis!()`. You can then set the number of threads with `TBLIS.set_num_threads(n)`.
+disabled with the command `disable_tblis()`, and enabled again with the command
+`enable_tblis()`. You can then set the number of threads with `TBLIS.set_num_threads(n)`.
 
 Currently only tensor contractions involving real elements (Float32 and Float64)
 get dispatched to TBLIS, since the complex number support of TBLIS is limited (https://github.com/devinamatthews/tblis/issues/18).

--- a/examples/tblis.jl
+++ b/examples/tblis.jl
@@ -24,7 +24,7 @@ let
   # Use BLAS
   #
 
-  disable_tblis!()
+  NDTensors.disable_tblis()
   BLAS.set_num_threads(nthreads)
 
   println()
@@ -39,7 +39,7 @@ let
   # Use TBLIS
   #
 
-  enable_tblis!()
+  NDTensors.enable_tblis()
   TBLIS.set_num_threads(nthreads)
 
   println()

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -18,9 +18,7 @@ using Base:
 using Base.Cartesian:
   @nexprs
 
-using Base.Threads:
-  @threads,
-  nthreads
+using Base.Threads
 
 #####################################
 # Imports and exports

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -18,6 +18,10 @@ using Base:
 using Base.Cartesian:
   @nexprs
 
+using Base.Threads:
+  @threads,
+  nthreads
+
 #####################################
 # Imports and exports
 #
@@ -68,6 +72,23 @@ include("deprecated.jl")
 
 const timer = TimerOutput()
 
+#####################################
+# Optional block sparse multithreading
+#
+
+const _use_threaded_blocksparse = Ref(false)
+
+use_threaded_blocksparse() = _use_threaded_blocksparse[]
+
+function enable_threaded_blocksparse!()
+  _use_threaded_blocksparse[] = true
+  return nothing
+end
+
+function disable_threaded_blocksparse!()
+  _use_threaded_blocksparse[] = false
+  return nothing
+end
 #####################################
 # Optional TBLIS contraction backend
 #

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -80,12 +80,12 @@ const _use_threaded_blocksparse = Ref(false)
 
 use_threaded_blocksparse() = _use_threaded_blocksparse[]
 
-function enable_threaded_blocksparse!()
+function enable_threaded_blocksparse()
   _use_threaded_blocksparse[] = true
   return nothing
 end
 
-function disable_threaded_blocksparse!()
+function disable_threaded_blocksparse()
   _use_threaded_blocksparse[] = false
   return nothing
 end
@@ -96,19 +96,24 @@ const _use_tblis = Ref(false)
 
 use_tblis() = _use_tblis[]
 
-function enable_tblis!()
+function enable_tblis()
   _use_tblis[] = true
   return nothing
 end
 
-function disable_tblis!()
+function disable_tblis()
   _use_tblis[] = false
   return nothing
 end
 
+# For backwards compatibility
+# XXX: deprecate
+enable_tblis!() = enable_tblis()
+disable_tblis!() = disable_tblis()
+
 function __init__()
   @require TBLIS="48530278-0828-4a49-9772-0f3830dfa1e9" begin
-    enable_tblis!()
+    enable_tblis()
     include("tblis.jl")
   end
 end

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -93,6 +93,7 @@ end
 #####################################
 # Optional TBLIS contraction backend
 #
+
 const _using_tblis = Ref(false)
 
 using_tblis() = _using_tblis[]
@@ -106,12 +107,6 @@ function disable_tblis()
   _using_tblis[] = false
   return nothing
 end
-
-# For backwards compatibility
-# XXX: deprecate
-use_tblis() = using_tblis()
-enable_tblis!() = enable_tblis()
-disable_tblis!() = disable_tblis()
 
 function __init__()
   @require TBLIS="48530278-0828-4a49-9772-0f3830dfa1e9" begin

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -76,38 +76,40 @@ const timer = TimerOutput()
 # Optional block sparse multithreading
 #
 
-const _use_threaded_blocksparse = Ref(false)
+const _using_threaded_blocksparse = Ref(false)
 
-use_threaded_blocksparse() = _use_threaded_blocksparse[]
+using_threaded_blocksparse() = _using_threaded_blocksparse[]
 
 function enable_threaded_blocksparse()
-  _use_threaded_blocksparse[] = true
+  _using_threaded_blocksparse[] = true
   return nothing
 end
 
 function disable_threaded_blocksparse()
-  _use_threaded_blocksparse[] = false
+  _using_threaded_blocksparse[] = false
   return nothing
 end
+
 #####################################
 # Optional TBLIS contraction backend
 #
-const _use_tblis = Ref(false)
+const _using_tblis = Ref(false)
 
-use_tblis() = _use_tblis[]
+using_tblis() = _using_tblis[]
 
 function enable_tblis()
-  _use_tblis[] = true
+  _using_tblis[] = true
   return nothing
 end
 
 function disable_tblis()
-  _use_tblis[] = false
+  _using_tblis[] = false
   return nothing
 end
 
 # For backwards compatibility
 # XXX: deprecate
+use_tblis() = using_tblis()
 enable_tblis!() = enable_tblis()
 disable_tblis!() = disable_tblis()
 

--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -1,5 +1,6 @@
 module NDTensors
 
+using Base.Threads
 using Compat
 using Dictionaries
 using Random
@@ -18,7 +19,8 @@ using Base:
 using Base.Cartesian:
   @nexprs
 
-using Base.Threads
+using Base.Threads:
+  @spawn
 
 #####################################
 # Imports and exports

--- a/src/blocksparse/block.jl
+++ b/src/blocksparse/block.jl
@@ -77,6 +77,8 @@ sethash!(b::Block, h::UInt) = (b.hash[] = h; return b)
 
 length(::Block{N}) where {N} = N
 
+isless(b1::Block, b2::Block) = isless(Tuple(b1), Tuple(b2))
+
 iterate(b::Block, args...) = iterate(b.data, args...)
 
 @propagate_inbounds function getindex(b::Block, i::Integer)

--- a/src/blocksparse/blocksparsetensor.jl
+++ b/src/blocksparse/blocksparsetensor.jl
@@ -861,13 +861,65 @@ function _threaded_contract!(R::BlockSparseTensor{ElR, NR}, labelsR,
   return R
 end
 
+#
+# blas_get_num_threads()
+# Get the number of BLAS threads
+# This can be replaced by BLAS.get_num_threads() in Julia v1.6
+#
+
+function guess_vendor()
+  # like determine_vendor, but guesses blas in some cases
+  # where determine_vendor returns :unknown
+  ret = BLAS.vendor()
+  if Sys.isapple() && (ret == :unknown)
+    ret = :osxblas
+  end
+  ret
+end
+
+_tryparse_env_int(key) = tryparse(Int, get(ENV, key, ""))
+
+blas_get_num_threads(;_blas=guess_vendor())::Union{Int, Nothing} = _get_num_threads()
+
+function _get_num_threads(; _blas = guess_vendor())::Union{Int, Nothing}
+  if _blas === :openblas || _blas === :openblas64
+    return Int(ccall((BLAS.@blasfunc(openblas_get_num_threads), BLAS.libblas), Cint, ()))
+  elseif _blas === :mkl
+    return Int(ccall((:mkl_get_max_threads, BLAS.libblas), Cint, ()))
+  elseif _blas === :osxblas
+    key = "VECLIB_MAXIMUM_THREADS"
+    nt = _tryparse_env_int(key)
+    if nt === nothing
+      @warn "Failed to read environment variable $key" maxlog=1
+    else
+      return nt
+    end
+  else
+    @assert _blas === :unknown
+  end
+  @warn "Could not get number of BLAS threads. Returning `nothing` instead." maxlog=1
+  return nothing
+end
+
 function contract!(R::BlockSparseTensor{ElR, NR}, labelsR,
                    T1::BlockSparseTensor{ElT1, N1}, labelsT1,
                    T2::BlockSparseTensor{ElT2, N2}, labelsT2,
                    contraction_plan) where {ElR, ElT1, ElT2,
                                             N1, N2, NR}
-  if use_threaded_blocksparse() && Threads.nthreads() > 1
+  if using_threaded_blocksparse() && Threads.nthreads() > 1
+    # Disable BLAS and Strided threading since they can conflict with the
+    # block sparse threading
+    # VERSION > v"1.5": use BLAS.get_num_threads()
+    original_blas_num_threads = blas_get_num_threads()
+    BLAS.set_num_threads(1)
+    original_strided_num_threads = Strided.disable_threads()
+
     _threaded_contract!(R, labelsR, T1, labelsT1, T2, labelsT2, contraction_plan)
+
+    # Reenable BLAS and Strided threading since they can conflict with the
+    BLAS.set_num_threads(original_blas_num_threads)
+    Strided.set_num_threads(original_strided_num_threads)
+
     return R
   end
   already_written_to = Dict{Block{NR}, Bool}()

--- a/src/blocksparse/combiner.jl
+++ b/src/blocksparse/combiner.jl
@@ -1,7 +1,7 @@
 
 function contract(T::BlockSparseTensor, labelsT,
                   C::CombinerTensor, labelsC)
-  @timeit_debug timer "Block sparse (un)combiner" begin
+  #@timeit_debug timer "Block sparse (un)combiner" begin
   # Get the label marking the combined index
   # By convention the combined index is the first one
   # TODO: consider storing the location of the combined
@@ -39,7 +39,7 @@ function contract(T::BlockSparseTensor, labelsT,
     Ruc = uncombine(T,indsRuc,cpos_in_labelsRc,blockperm(C),blockcomb(C))
     return Ruc
   end
-  end
+  #end # @timeit
 end
 
 contract(C::CombinerTensor, labelsC, T::BlockSparseTensor, labelsT) =

--- a/src/blocksparse/linearalgebra.jl
+++ b/src/blocksparse/linearalgebra.jl
@@ -36,7 +36,7 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
 
   truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
 
-  @timeit_debug timer "block sparse svd" begin
+  #@timeit_debug timer "block sparse svd" begin
   Us = Vector{DenseTensor{ElT, 2}}(undef, nnzblocks(T))
   Ss = Vector{DiagTensor{real(ElT), 2}}(undef, nnzblocks(T))
   Vs = Vector{DenseTensor{ElT, 2}}(undef, nnzblocks(T))
@@ -181,7 +181,7 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
   end
 
   return U,S,V,Spectrum(d,truncerr)
-  end # @timeit_debug
+  #end # @timeit_debug
 end
 
 _eigen_eltypes(T::Hermitian{ElT,<:BlockSparseMatrix{ElT}}) where {ElT} = real(ElT), ElT

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -458,9 +458,9 @@ function _gemm!(tA, tB, alpha,
                 A::AbstractVecOrMat{<:LinearAlgebra.BlasFloat},
                 B::AbstractVecOrMat{<:LinearAlgebra.BlasFloat},
                 beta, C::AbstractVecOrMat{<:LinearAlgebra.BlasFloat})
-  @timeit_debug timer "BLAS.gemm!" begin
+  #@timeit_debug timer "BLAS.gemm!" begin
   BLAS.gemm!(tA, tB, alpha, A, B, beta, C)
-  end
+  #end # @timeit
 end
 
 # generic matmul
@@ -538,7 +538,7 @@ end
 # TODO: move to tensor.jl?
 function contract(T1::Tensor, labelsT1, T2::Tensor,
                   labelsT2, labelsR = contract_labels(labelsT1, labelsT2))
-  @timeit_debug timer "dense contract" begin
+  #@timeit_debug timer "dense contract" begin
   # TODO: put the contract_inds logic into contraction_output,
   # call like R = contraction_ouput(T1,labelsT1,T2,labelsT2)
   #indsR = contract_inds(inds(T1),labelsT1,inds(T2),labelsT2,labelsR)
@@ -551,7 +551,7 @@ function contract(T1::Tensor, labelsT1, T2::Tensor,
                  T1, labelsT1,
                  T2, labelsT2)
   return R
-  end
+  #end @timeit
 end
 
 # Move to tensor.jl? Is this generic for all storage types?
@@ -773,20 +773,22 @@ function contract!(R::DenseTensor{ElR, NR}, labelsR,
                    T1::DenseTensor{ElT1, N1}, labelsT1,
                    T2::DenseTensor{ElT2, N2}, labelsT2,
                    α::Elα = one(ElR), β::Elβ = zero(ElR)) where {Elα, Elβ, ElR, ElT1, ElT2, NR, N1, N2}
-  @timeit_debug timer "dense contract!" begin
-
+  #@timeit_debug timer "dense contract!" begin
   # Special case for scalar tensors
-  if nnz(T1) == 1 || nnz(T2) == 1
-    @timeit_debug timer "special length 1 cases" begin
-    _contract_scalar!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
-    end
-    return R
-  end
+  #@show nnz(T1), nnz(T2)
+  #if nnz(T1) == 1 || nnz(T2) == 1
+  #  #@timeit_debug timer "special length 1 cases" begin
+  #  println("Use _contract_scalar!")
+  #  @show nnz(T1), nnz(T2), nnz(R)
+  #  _contract_scalar!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
+  #  #end
+  #  return R
+  #end
 
   if use_tblis() && ElR <: LinearAlgebra.BlasReal && (ElR == ElT1 == ElT2 == Elα == Elβ)
-    @timeit_debug timer "TBLIS contract!" begin
+    #@timeit_debug timer "TBLIS contract!" begin
     contract!(Val(:TBLIS), R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
-    end
+    #end
     return R
   end
 
@@ -822,7 +824,7 @@ function contract!(R::DenseTensor{ElR, NR}, labelsR,
 
   _contract!(R,T1,T2,props,α,β)
   return R
-  end
+  #end
 end
 
 function _contract!(CT::DenseTensor{El, NC},
@@ -839,9 +841,9 @@ function _contract!(CT::DenseTensor{El, NC},
   tA = 'N'
   if props.permuteA
     pA = NTuple{NA, Int}(props.PA)
-    @timeit_debug timer "_contract!: permutedims A" begin
+    #@timeit_debug timer "_contract!: permutedims A" begin
     @strided Ap = permutedims(A, pA)
-    end
+    #end # @timeit
     AM = ReshapedArray(Ap, (props.dmid, props.dleft), ())
     tA = 'T'
   else
@@ -857,9 +859,9 @@ function _contract!(CT::DenseTensor{El, NC},
   tB = 'N'
   if props.permuteB
     pB = NTuple{NB, Int}(props.PB)
-    @timeit_debug timer "_contract!: permutedims B" begin
+    #@timeit_debug timer "_contract!: permutedims B" begin
     @strided Bp = permutedims(B, pB)
-    end
+    #end # @timeit
     BM = ReshapedArray(Bp, (props.dmid, props.dright), ())
   else
     if Btrans(props)
@@ -893,9 +895,9 @@ function _contract!(CT::DenseTensor{El, NC},
     pC = NTuple{NC, Int}(props.PC)
     Cr = ReshapedArray(CM.parent, props.newCrange, ())
     # TODO: use invperm(pC) here?
-    @timeit_debug timer "_contract!: permutedims C" begin
+    #@timeit_debug timer "_contract!: permutedims C" begin
     @strided C .= permutedims(Cr, pC)
-    end
+    #end # @timeit
   end
   return CT
 end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -846,9 +846,6 @@ function _contract!(CT::DenseTensor{El, NC},
                     props::ContractionProperties,
                     α::Number = one(El),
                     β::Number = zero(El)) where {El, NC, NA, NB}
-  # Disable Strided threading (it seems to conflict with BLAS threading?)
-  original_strided_num_threads = Strided.disable_threads()
-
   # TODO: directly use Tensor instead of Array
   C = ReshapedArray(data(store(CT)), dims(inds(CT)), ())
   A = ReshapedArray(data(store(AT)), dims(inds(AT)), ())
@@ -915,9 +912,6 @@ function _contract!(CT::DenseTensor{El, NC},
     @strided C .= permutedims(Cr, pC)
     #end # @timeit
   end
-
-  # Reenable Strided threading (it seems to conflict with BLAS threading?)
-  Strided.set_num_threads(original_strided_num_threads)
 
   return CT
 end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -792,19 +792,13 @@ function contract!(R::DenseTensor{ElR, NR}, labelsR,
                    T1::DenseTensor{ElT1, N1}, labelsT1,
                    T2::DenseTensor{ElT2, N2}, labelsT2,
                    α::Elα = one(ElR), β::Elβ = zero(ElR)) where {Elα, Elβ, ElR, ElT1, ElT2, NR, N1, N2}
-  #@timeit_debug timer "dense contract!" begin
   # Special case for scalar tensors
-  #@show nnz(T1), nnz(T2)
-  #if nnz(T1) == 1 || nnz(T2) == 1
-  #  #@timeit_debug timer "special length 1 cases" begin
-  #  println("Use _contract_scalar!")
-  #  @show nnz(T1), nnz(T2), nnz(R)
-  #  _contract_scalar!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
-  #  #end
-  #  return R
-  #end
+  if nnz(T1) == 1 || nnz(T2) == 1
+    _contract_scalar!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
+    return R
+  end
 
-  if use_tblis() && ElR <: LinearAlgebra.BlasReal && (ElR == ElT1 == ElT2 == Elα == Elβ)
+  if using_tblis() && ElR <: LinearAlgebra.BlasReal && (ElR == ElT1 == ElT2 == Elα == Elβ)
     #@timeit_debug timer "TBLIS contract!" begin
     contract!(Val(:TBLIS), R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
     #end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -852,6 +852,9 @@ function _contract!(CT::DenseTensor{El, NC},
                     props::ContractionProperties,
                     α::Number = one(El),
                     β::Number = zero(El)) where {El, NC, NA, NB}
+  # Disable Strided threading (it seems to conflict with BLAS threading?)
+  original_strided_num_threads = Strided.disable_threads()
+
   # TODO: directly use Tensor instead of Array
   C = ReshapedArray(data(store(CT)), dims(inds(CT)), ())
   A = ReshapedArray(data(store(AT)), dims(inds(AT)), ())
@@ -918,6 +921,10 @@ function _contract!(CT::DenseTensor{El, NC},
     @strided C .= permutedims(Cr, pC)
     #end # @timeit
   end
+
+  # Reenable Strided threading (it seems to conflict with BLAS threading?)
+  Strided.set_num_threads(original_strided_num_threads)
+
   return CT
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,4 +1,9 @@
 
+# NDTensors.jl
+@deprecate use_tblis() NDTensors.using_tblis()
+@deprecate enable_tblis!() NDTensors.enable_tblis()
+@deprecate disable_tblis!() NDTensors.disable_tblis()
+
 @deprecate addblock!! insertblock!!
 @deprecate addblock! insertblock!
 

--- a/src/diag.jl
+++ b/src/diag.jl
@@ -403,7 +403,7 @@ function contract!(C::DenseTensor{ElC,NC},Clabels,
                    convert_to_dense::Bool = true) where {ElA,NA,
                                                          ElB,NB,
                                                          ElC,NC}
-  @timeit_debug timer "diag-dense contract!" begin 
+  #@timeit_debug timer "diag-dense contract!" begin 
   if all(i -> i < 0, Blabels)
     # If all of B is contracted
     # TODO: can also check NC+NB==NA
@@ -486,7 +486,7 @@ function contract!(C::DenseTensor{ElC,NC},Clabels,
       end
     end
   end
-  end
+  #end # @timeit
 end
 
 contract!(C::DenseTensor, Clabels, A::DenseTensor, Alabels,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,7 +1,5 @@
 export 
 # NDTensors.jl
-  disable_tblis!,
-  enable_tblis!,
   insertblock!!,
   setindex,
   setindex!!,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -22,6 +22,7 @@ import Base:
   getindex,
   hash,
   isempty,
+  isless,
   iterate,
   length,
   ndims,

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -107,7 +107,7 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
                                   use_relative_cutoff)
   alg::String = get(kwargs, :alg, "divide_and_conquer")
 
-  @timeit_debug timer "dense svd" begin
+  #@timeit_debug timer "dense svd" begin
   if alg == "divide_and_conquer"
     MUSV = svd_catch_error(matrix(T); alg = LinearAlgebra.DivideAndConquer())
   elseif alg == "qr_iteration"
@@ -147,7 +147,7 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
   end
   MU, MS, MV = MUSV
   conj!(MV)
-  end # @timeit_debug
+  #end # @timeit_debug
 
   P = MS .^ 2
   if truncate

--- a/test/blocksparse.jl
+++ b/test/blocksparse.jl
@@ -292,7 +292,7 @@ using LinearAlgebra
     A = BlockSparseTensor([(1,1),(2,2)],[2,4],[2,4])
     randn!(A)
     expT = exp(A)
-    @test isapprox(norm(array(expT) - exp(array(A))), 0.0; atol=1e-14)
+    @test isapprox(norm(array(expT) - exp(array(A))), 0.0; atol=1e-13)
 
     # Hermitian case
     A = BlockSparseTensor(ComplexF64,[(1,1),(2,2)],([2,2],[2,2]))


### PR DESCRIPTION
This adds multithreading to block sparse contractions using Julia's native multithreading (`Threads.@spawn`). The basic interface is as follows. Start Julia with more than one thread with:
```julia
julia -t 4
```
or
```julia
JULIA_NUM_THREADS=4 julia
```
Then, enable block sparse multithreading with `NDTensors.enable_threaded_blocksparse()` (you should probably also turn off BLAS and Strided multithreading, which we could automate within NDTensors):
```julia
using ITensors
using LinearAlgebra

BLAS.set_num_threads(1)
ITensors.Strided.disable_threads()

@show Threads.nthreads()

N = 4
d = 1000
i = Index([QN(0, N) => d for n in 1:N], "i")

# Matrix multiplication
A = randomITensor(i'', dag(i'))
B = randomITensor(i', dag(i))

ITensors.disable_threaded_blocksparse()
@show ITensors.using_threaded_blocksparse()
C1 = @time A * B

ITensors.enable_threaded_blocksparse()
@show ITensors.using_threaded_blocksparse()
C2 = @time A * B
ITensors.disable_threaded_blocksparse()

@show C1 ≈ C2
```
returns:
```julia
Threads.nthreads() = 4
ITensors.using_threaded_blocksparse() = false
  2.204602 seconds (508 allocations: 122.121 MiB)
ITensors.using_threaded_blocksparse() = true
  0.688744 seconds (1.76 k allocations: 122.205 MiB)
C1 ≈ C2 = true
```