### PR TITLE
Update HDF5 to versions 0.14, 0.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 [compat]
 Compat = "2.1, 3"
 Dictionaries = "0.3.5"
-HDF5 = "0.12, 0.13, 0.14"
+HDF5 = "0.14"
 Requires = "1.1"
 StaticArrays = "0.12, 1.0"
 Strided = "0.3, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 [compat]
 Compat = "2.1, 3"
 Dictionaries = "0.3.5"
-HDF5 = "0.14"
+HDF5 = "0.14, 0.15"
 Requires = "1.1"
 StaticArrays = "0.12, 1.0"
 Strided = "0.3, 1"

--- a/src/blocksparse/blocksparse.jl
+++ b/src/blocksparse/blocksparse.jl
@@ -211,12 +211,12 @@ function array_to_offsets(a,N::Int)
   return boff
 end
 
-function HDF5.write(parent::Union{HDF5File, HDF5Group},
+function HDF5.write(parent::Union{HDF5.File, HDF5.Group},
                     name::String,
                     B::BlockSparse)
-  g = g_create(parent,name)
-  attrs(g)["type"] = "BlockSparse{$(eltype(B))}"
-  attrs(g)["version"] = 1
+  g = create_group(parent,name)
+  attributes(g)["type"] = "BlockSparse{$(eltype(B))}"
+  attributes(g)["version"] = 1
   if eltype(B) != Nothing
     write(g,"ndims",ndims(B))
     write(g,"data",data(B))
@@ -225,13 +225,13 @@ function HDF5.write(parent::Union{HDF5File, HDF5Group},
   end
 end
 
-function HDF5.read(parent::Union{HDF5File,HDF5Group},
+function HDF5.read(parent::Union{HDF5.File,HDF5.Group},
                    name::AbstractString,
                    ::Type{Store}) where {Store <: BlockSparse}
-  g = g_open(parent,name)
+  g = open_group(parent,name)
   ElT = eltype(Store)
   typestr = "BlockSparse{$ElT}"
-  if read(attrs(g)["type"]) != typestr
+  if read(attributes(g)["type"]) != typestr
     error("HDF5 group or file does not contain $typestr data")
   end
   N = read(g,"ndims")

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1047,25 +1047,25 @@ function LinearAlgebra.exp(T::DenseTensor{ElT,N},
   end
 end
 
-function HDF5.write(parent::Union{HDF5File, HDF5Group}, 
+function HDF5.write(parent::Union{HDF5.File, HDF5.Group}, 
                     name::String, 
                     D::Store) where {Store <: Dense}
-  g = g_create(parent,name)
-  attrs(g)["type"] = "Dense{$(eltype(Store))}"
-  attrs(g)["version"] = 1
+  g = create_group(parent,name)
+  attributes(g)["type"] = "Dense{$(eltype(Store))}"
+  attributes(g)["version"] = 1
   if eltype(D) != Nothing
     write(g,"data",D.data)
   end
 end
 
 
-function HDF5.read(parent::Union{HDF5File,HDF5Group},
+function HDF5.read(parent::Union{HDF5.File,HDF5.Group},
                    name::AbstractString,
                    ::Type{Store}) where {Store <: Dense}
-  g = g_open(parent,name)
+  g = open_group(parent,name)
   ElT = eltype(Store)
   typestr = "Dense{$ElT}"
-  if read(attrs(g)["type"]) != typestr
+  if read(attributes(g)["type"]) != typestr
     error("HDF5 group or file does not contain $typestr data")
   end
   if ElT == Nothing


### PR DESCRIPTION
Updates NDTensors code and Project.toml to be
compatible with HDF5.jl versions 0.14.x and 0.15.x

- Update to be compatible with HDF5.jl v0.14
- Allow HDF5.jl v0.15
