### PR TITLE
Small threading bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.1.22"
+version = "0.1.23"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/blocksparse/blocksparsetensor.jl
+++ b/src/blocksparse/blocksparsetensor.jl
@@ -932,6 +932,9 @@ function contract!(R::BlockSparseTensor{ElR, NR}, labelsR,
                    T2::BlockSparseTensor{ElT2, N2}, labelsT2,
                    contraction_plan) where {ElR, ElT1, ElT2,
                                             N1, N2, NR}
+  if isempty(contraction_plan)
+    return R
+  end
   if using_threaded_blocksparse() && nthreads() > 1
     _threaded_contract!(R, labelsR, T1, labelsT1, T2, labelsT2,
                         contraction_plan)


### PR DESCRIPTION
This fixes a bug in the multithreaded block sparse code when a block sparse contraction doesn't result in any viable blocks, for example, something like:
```julia
using ITensors

i = Index([QN(0) => 1, QN(1) => 1])
A = emptyITensor(i', dag(i))
B = emptyITensor(i', dag(i))
A[i' => 1, i => 1] = 11.0
B[i' => 2, i => 2] = 22.0

using_threaded_blocksparse = ITensors.disable_threaded_blocksparse()
C1 = A' * B
ITensors.enable_threaded_blocksparse()
C2 = A' * B
if using_threaded_blocksparse
  ITensors.enable_threaded_blocksparse()
else
  ITensors.disable_threaded_blocksparse()
end
```
This showed up in a very particular DMRG calculation (2D Hubbard model conserving spin and particle number, with the Hamiltonian modified by `splitblocks` and using multithreading over blocks). It only showed up in the multithreading code since the serial code automatically handled this special case.