### PR TITLE
ArrayInterface compatibility

### DIFF
--- a/src/empty.jl
+++ b/src/empty.jl
@@ -106,6 +106,8 @@ end
   return _setindex(T, x, I...)
 end
 
+# This is needed to fix an ambiguity error with ArrayInterface.jl
+# https://github.com/ITensor/NDTensors.jl/issues/62
 @propagate_inbounds function setindex(T::EmptyTensor, x, I::Int)
   return _setindex(T, x, I)
 end

--- a/src/empty.jl
+++ b/src/empty.jl
@@ -96,11 +96,18 @@ end
 insertblock!!(T::EmptyTensor{<: Number, N}, block) where {N} =
   insertblock(T, block)
 
-@propagate_inbounds function setindex(T::EmptyTensor{<: Number, N},
-                                      x, I...) where {N}
+@propagate_inbounds function _setindex(T::EmptyTensor, x, I...)
   R = zeros(T)
   R[I...] = x
   return R
+end
+
+@propagate_inbounds function setindex(T::EmptyTensor, x, I...)
+  return _setindex(T, x, I...)
+end
+
+@propagate_inbounds function setindex(T::EmptyTensor, x, I::Int)
+  return _setindex(T, x, I)
 end
 
 setindex!!(T::EmptyTensor, x, I...) = setindex(T, x, I...)


### PR DESCRIPTION
This fixes #62 by adding a more specific `setindex(::EmptyTensor, ::Any, ::Int)` definition.