### PR TITLE
Some changes to account for the new Index Tuple storage in ITensor

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -200,7 +200,7 @@ iterate(T::DenseTensor,args...) = iterate(store(T),args...)
 
 function _zeros(TensorT::Type{<: DenseTensor},
                 inds)
-  return tensor(zeros(storetype(TensorT), dim(inds)), inds)
+  return tensor(zeros(storagetype(TensorT), dim(inds)), inds)
 end
 
 function zeros(TensorT::Type{<: DenseTensor}, inds)
@@ -217,7 +217,7 @@ function zeros(TensorT::Type{<: DenseTensor}, inds::Tuple{})
 end
 
 function _similar(TensorT::Type{<: DenseTensor}, inds)
-  return tensor(similar(storetype(TensorT), dim(inds)), inds)
+  return tensor(similar(storagetype(TensorT), dim(inds)), inds)
 end
 
 function similar(TensorT::Type{<: DenseTensor}, inds)
@@ -245,39 +245,25 @@ similar(T::DenseTensor,inds::Dims) = _similar(T, inds)
 # Single index
 #
 
-@propagate_inbounds function _getindex(T::DenseTensor{<:Number,N},
-                                       I::CartesianIndex{N}) where {N}
-  return store(T)[@inbounds LinearIndices(T)[CartesianIndex(I)]]
+@propagate_inbounds function getindex(T::DenseTensor{<:Number,N}, I::Vararg{Integer, N}) where {N}
+  Base.@_inline_meta
+  return getindex(data(T), Base._sub2ind(T, I...))
 end
 
-@propagate_inbounds function getindex(T::DenseTensor{<:Number,N},
-                                      I::Vararg{Int,N}) where {N}
-  return _getindex(T,CartesianIndex(I))
+@propagate_inbounds function getindex(T::DenseTensor{<:Number,N}, I::CartesianIndex{N}) where {N}
+  Base.@_inline_meta
+  return getindex(T, I.I...)
 end
 
-@propagate_inbounds function getindex(T::DenseTensor{<:Number,N},
-                                      I::CartesianIndex{N}) where {N}
-  return _getindex(T,I)
-end
-
-@propagate_inbounds function _setindex!(T::DenseTensor{<:Number,N},
-                                        x::Number,
-                                        I::CartesianIndex{N}) where {N}
-  store(T)[@inbounds LinearIndices(T)[CartesianIndex(I)]] = x
+@propagate_inbounds function setindex!(T::DenseTensor{<:Number,N}, x::Number, I::Vararg{Integer, N}) where {N}
+  Base.@_inline_meta
+  setindex!(data(T), x, Base._sub2ind(T, I...))
   return T
 end
 
-@propagate_inbounds function setindex!(T::DenseTensor{<:Number,N},
-                                       x::Number,
-                                       I::Vararg{Int,N}) where {N}
-  _setindex!(T,x,CartesianIndex(I))
-  return T
-end
-
-@propagate_inbounds function setindex!(T::DenseTensor{<:Number,N},
-                                       x::Number,
-                                       I::CartesianIndex{N}) where {N}
-  _setindex!(T,x,I)
+@propagate_inbounds function setindex!(T::DenseTensor{<:Number,N}, x::Number, I::CartesianIndex{N}) where {N}
+  Base.@_inline_meta
+  setindex!(T, x, I.I...)
   return T
 end
 
@@ -285,9 +271,9 @@ end
 # Linear indexing
 #
 
-@propagate_inbounds getindex(T::DenseTensor,i::Int) = store(T)[i]
+@propagate_inbounds @inline getindex(T::DenseTensor, i::Integer) = store(T)[i]
 
-@propagate_inbounds setindex!(T::DenseTensor,v,i::Int) = (store(T)[i] = v; T)
+@propagate_inbounds @inline setindex!(T::DenseTensor, v, i::Integer) = (store(T)[i] = v; T)
 
 #
 # Slicing

--- a/src/diag.jl
+++ b/src/diag.jl
@@ -189,12 +189,12 @@ end
 
 function zeros(TensorT::Type{<: DiagTensor},
                     inds)
-  return tensor(zeros(storetype(TensorT), mindim(inds)), inds)
+  return tensor(zeros(storagetype(TensorT), mindim(inds)), inds)
 end
 
 function zeros(TensorT::Type{<: DiagTensor},
                     inds::Tuple{})
-  return tensor(zeros(storetype(TensorT), mindim(inds)), inds)
+  return tensor(zeros(storagetype(TensorT), mindim(inds)), inds)
 end
 
 # Needed to get slice of DiagTensor like T[1:3,1:3]

--- a/src/dims.jl
+++ b/src/dims.jl
@@ -9,10 +9,10 @@ export dense,
 dims(ds::Dims) = ds
 
 # Generic dims function
-dims(inds) = ntuple(i -> dim(inds[i]), Val(length(inds)))
+dims(inds::Tuple) = ntuple(i -> dim(@inbounds inds[i]), Val(length(inds)))
 
 # Generic dim function
-dim(inds) = prod(dims(inds))
+dim(inds::Tuple) = prod(dims(inds))
 
 dims(::Tuple{}) = ()
 
@@ -24,7 +24,7 @@ dense(::Type{DimsT}) where {DimsT<:Dims} = DimsT
 
 dim(ds::Dims) = prod(ds)
 
-dim(ds::Dims,i::Int) = dims(ds)[i]
+dim(ds::Dims, i::Int) = dims(ds)[i]
 
 mindim(inds::Tuple) = minimum(dims(inds))
 

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -29,10 +29,7 @@ end
     Tensor(store::TensorStorage, inds)
 
 Construct a Tensor from a tensor storage and indices.
-The storage data is copied into the Tensor.
-
-See also tensor(store::TensorStorage, inds)
-which makes a view of the storage.
+The Tensor holds a view of the storage data.
 """
 function Tensor(store::StoreT, inds::IndsT) where {StoreT<:TensorStorage, IndsT}
   return Tensor{eltype(store),length(inds),StoreT,IndsT}(inds, store)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -5,14 +5,12 @@ Tensor{StoreT,IndsT}
 A plain old tensor (with order independent
 interface and no assumption of labels)
 """
-struct Tensor{ElT,
-              N,
-              StoreT <: TensorStorage,
-              IndsT} <: AbstractArray{ElT,N}
-  store::StoreT
+struct Tensor{ElT, N, StoreT <: TensorStorage, IndsT} <: AbstractArray{ElT,N}
+  storage::StoreT
   inds::IndsT
+
   """
-  Tensor{ElT,N,StoreT,IndsT}(inds, store::StorageType)
+      Tensor{ElT,N,StoreT,IndsT}(inds, store::StorageType)
 
   Internal constructor for creating a Tensor from the 
   storage and indices.
@@ -22,32 +20,13 @@ struct Tensor{ElT,
   For normal usage, use the Tensor(store::TensorStorage, inds)
   and tensor(store::TensorStorage, inds) constructors.
   """
-  function Tensor{ElT,N,StoreT,IndsT}(inds,
-                                      store::TensorStorage) where {ElT,
-                                                                   N,
-                                                                   StoreT,
-                                                                   IndsT}
-    new{ElT,N,StoreT,IndsT}(store, inds)
+  function Tensor{ElT, N, StoreT, IndsT}(inds, store) where {ElT, N, StoreT, IndsT}
+    new{ElT, N, StoreT, IndsT}(store, inds)
   end
 end
 
 """
-tensor(store::TensorStorage, inds)
-
-Construct a Tensor from a tensor storage and indices.
-The Tensor is a view of the tensor storage.
-
-See also Tensor(store::TensorStorage, inds)
-which makes a copy of the storage.
-"""
-function tensor(store::StoreT,
-                inds::IndsT) where {StoreT<:TensorStorage,
-                                    IndsT}
-  return Tensor{eltype(store),length(inds),StoreT,IndsT}(inds, store)
-end
-
-"""
-Tensor(store::TensorStorage, inds)
+    Tensor(store::TensorStorage, inds)
 
 Construct a Tensor from a tensor storage and indices.
 The storage data is copied into the Tensor.
@@ -55,19 +34,26 @@ The storage data is copied into the Tensor.
 See also tensor(store::TensorStorage, inds)
 which makes a view of the storage.
 """
-Tensor(store::TensorStorage, inds) = tensor(copy(store), inds)
+function Tensor(store::StoreT, inds::IndsT) where {StoreT<:TensorStorage, IndsT}
+  return Tensor{eltype(store),length(inds),StoreT,IndsT}(inds, store)
+end
 
-store(T::Tensor) = T.store
+# TODO: deprecate
+tensor(args...; kwargs...) = Tensor(args...; kwargs...)
+
+storage(T::Tensor) = T.storage
+
+# TODO: deprecate
+store(T::Tensor) = storage(T)
 
 data(T::Tensor) = data(store(T))
 
-storetype(::Tensor{<: Number,
-                   <: Any,
-                   StoreT}) where {StoreT} = StoreT
+storagetype(::Tensor{<: Any, <: Any, StoreT}) where {StoreT} = StoreT
 
-storetype(::Type{<: Tensor{<: Number,
-                           <: Any,
-                           StoreT}}) where {StoreT} = StoreT
+storagetype(::Type{<: Tensor{<: Any, <: Any, StoreT}}) where {StoreT} = StoreT
+
+# TODO: deprecate
+storetype(args...) = storagetype(args...)
 
 inds(T::Tensor) = T.inds
 
@@ -79,9 +65,9 @@ eltype(::Tensor{ElT}) where {ElT} = ElT
 
 strides(T::Tensor) = dim_to_strides(inds(T))
 
-setstorage(T,nstore) = tensor(nstore,inds(T))
+setstorage(T, nstore) = Tensor(nstore, inds(T))
 
-setinds(T,ninds) = tensor(store(T),ninds)
+setinds(T, ninds) = Tensor(storage(T), ninds)
 
 #
 # Generic Tensor functions
@@ -91,6 +77,7 @@ setinds(T,ninds) = tensor(store(T),ninds)
 dims(T::Tensor) = dims(inds(T))
 dim(T::Tensor) = dim(inds(T))
 dim(T::Tensor,i::Int) = dim(inds(T),i)
+maxdim(T::Tensor) = maxdim(inds(T))
 mindim(T::Tensor) = mindim(inds(T))
 diaglength(T::Tensor) = mindim(T)
 size(T::Tensor) = dims(T)
@@ -120,8 +107,7 @@ Base.imag(T::Tensor) = setstorage(T,imag(store(T)))
 
 LinearAlgebra.norm(T::Tensor) = norm(store(T))
 
-conj(T::Tensor;
-     kwargs...) = setstorage(T,conj(store(T); kwargs...))
+conj(T::Tensor; kwargs...) = setstorage(T, conj(store(T); kwargs...))
 
 Random.randn!(T::Tensor) = (randn!(store(T)); T)
 
@@ -155,12 +141,11 @@ similar(T::Tensor,
              dims) where {S<:Number} = _similar_from_dims(T, S, dims)
 
 # To handle method ambiguity with AbstractArray
-similar(T::Tensor,
-             ::Type{S},
-             dims::Dims) where {S<:Number} = _similar_from_dims(T, S, dims)
+similar(T::Tensor, ::Type{S}, dims::Dims) where {S<:Number} =
+  _similar_from_dims(T, S, dims)
 
-_similar_from_dims(T::Tensor,
-                   dims) = tensor(similar(store(T), dim(dims)), dims)
+_similar_from_dims(T::Tensor, dims) =
+  tensor(similar(store(T), dim(dims)), dims)
 
 function _similar_from_dims(T::Tensor,::Type{S},dims) where {S<:Number}
   return tensor(similar(store(T),S,dim(dims)),dims)
@@ -177,10 +162,10 @@ function zeros(TensorT::Type{<:Tensor{ElT,N,StoreT}},
 end
 
 function promote_rule(::Type{<:Tensor{ElT1,N1,StoreT1,IndsT1}},
-                           ::Type{<:Tensor{ElT2,N2,StoreT2,IndsT2}}) where {ElT1,ElT2,
-                                                                            N1,N2,
-                                                                            StoreT1,StoreT2,
-                                                                            IndsT1,IndsT2}
+                      ::Type{<:Tensor{ElT2,N2,StoreT2,IndsT2}}) where {ElT1,ElT2,
+                                                                       N1,N2,
+                                                                       StoreT1,StoreT2,
+                                                                       IndsT1,IndsT2}
   StoreR = promote_type(StoreT1,StoreT2)
   ElR = eltype(StoreR)
   return Tensor{ElR,N3,StoreR,IndsR} where {N3,IndsR}
@@ -287,7 +272,7 @@ end
 # Some generic getindex and setindex! functionality
 #
 
-setindex!!(T::Tensor, x, I...) = setindex!(T, x, I...)
+@propagate_inbounds @inline setindex!!(T::Tensor, x, I...) = setindex!(T, x, I...)
 
 insertblock!!(T::Tensor, block) = insertblock!(T, block)
 


### PR DESCRIPTION
This PR accompanies https://github.com/ITensor/ITensors.jl/pull/626. It makes some small adjustments accounting for the change to using an Index Tuple storage in the ITensor type, as well as some other miscellaneous changes. 

The most significant design change is making it so that calls like `Tensor(Dense(randn(4)), (2, 2))` now return a Tensor that stores a view of the tensor storage instead of making a copy. This effectively would deprecate `tensor`.