### PR TITLE
Reference correct tuple type on recent julia master

### DIFF
--- a/src/blocksparse/block.jl
+++ b/src/blocksparse/block.jl
@@ -120,13 +120,25 @@ _hash(::Tuple{}, h::UInt) = h + Base.tuplehash_seed
     @nexprs $N i -> out = hash(b[$N-i+1], out)
   end
 end
-# Stop inlining after some number of arguments to avoid code blowup
-function _hash(t::Base.Any16, h::UInt)
-  out = h + Base.tuplehash_seed
-  for i = length(t):-1:1
-      out = hash(t[i], out)
-  end
-  return out
+
+if VERSION < v"1.7.0-DEV.933"
+    # Stop inlining after some number of arguments to avoid code blowup
+    function _hash(t::Base.Any16, h::UInt)
+      out = h + Base.tuplehash_seed
+      for i = length(t):-1:1
+          out = hash(t[i], out)
+      end
+      return out
+    end
+else
+    # Stop inlining after some number of arguments to avoid code blowup
+    function _hash(t::Base.Any32, h::UInt)
+      out = h + Base.tuplehash_seed
+      for i = length(t):-1:1
+          out = hash(t[i], out)
+      end
+      return out
+    end
 end
 
 hash(b::Block) = UInt(b.hash)


### PR DESCRIPTION
Should allow `NDTensors` to precompile on recent julia master versions.