### PR TITLE
Introduce AliasStyle to help with functions that have different aliasing behaviors

### DIFF
--- a/src/NDTensors.jl
+++ b/src/NDTensors.jl
@@ -31,6 +31,7 @@ include("imports.jl")
 #####################################
 # DenseTensor and DiagTensor
 #
+include("aliasstyle.jl")
 include("tupletools.jl")
 include("dims.jl")
 include("tensorstorage.jl")

--- a/src/aliasstyle.jl
+++ b/src/aliasstyle.jl
@@ -1,0 +1,35 @@
+"""
+    AliasStyle
+
+A trait that determines the aliasing behavior of a constructor or function,
+for example whether or not a function or constructor might return an alias
+of one of the inputs (i.e. the output shares memory with one of the inputs,
+such that modifying the output also modifies the input or vice versa).
+
+See also [`AllowAlias`](@ref) and [`NeverAlias`](@ref).
+"""
+abstract type AliasStyle end
+
+"""
+    AllowAlias
+
+Singleton type used in a constructor or function indicating
+that the constructor or function may return an alias of the input data when
+possible, i.e. the output may share data with the input. For a constructor
+`T(AllowAlias(), args...)`, this would act like `Base.convert(T, args...)`.
+
+See also [`AliasStyle`](@ref) and [`NeverAlias`](@ref).
+"""
+struct AllowAlias <: AliasStyle end
+
+"""
+    NeverAlias
+
+Singleton type used in a constructor or function indicating
+that the constructor or function will never return an alias of the input data,
+i.e. the output will never share data with one of the inputs.
+
+See also [`AliasStyle`](@ref) and [`AllowAlias`](@ref).
+"""
+struct NeverAlias <: AliasStyle end
+

--- a/src/blocksparse/blocksparsetensor.jl
+++ b/src/blocksparse/blocksparsetensor.jl
@@ -192,18 +192,18 @@ end
                                       i::Vararg{Int,N}) where {ElT,N}
   offset,_ = indexoffset(T,i...)
   isnothing(offset) && return zero(ElT)
-  return store(T)[offset]
+  return storage(T)[offset]
 end
 
 @propagate_inbounds function getindex(T::BlockSparseTensor{ElT,0}) where {ElT}
   nnzblocks(T) == 0 && return zero(ElT)
-  return store(T)[]
+  return storage(T)[]
 end
 
 # These may not be valid if the Tensor has no blocks
-#@propagate_inbounds getindex(T::BlockSparseTensor{<:Number,1},ind::Int) = store(T)[ind]
+#@propagate_inbounds getindex(T::BlockSparseTensor{<:Number,1},ind::Int) = storage(T)[ind]
 
-#@propagate_inbounds getindex(T::BlockSparseTensor{<:Number,0}) = store(T)[1]
+#@propagate_inbounds getindex(T::BlockSparseTensor{<:Number,0}) = storage(T)[1]
 
 # Add the specified block to the BlockSparseTensor
 # Insert it such that the blocks remain ordered.
@@ -216,7 +216,7 @@ function insertblock_offset!(T::BlockSparseTensor{ElT, N},
   newoffset = nnz(T)
   insert!(blockoffsets(T), newblock, newoffset)
   # Insert new block into data
-  splice!(data(store(T)), newoffset+1:newoffset, zeros(ElT,newdim))
+  splice!(data(storage(T)), newoffset+1:newoffset, zeros(ElT,newdim))
   return newoffset
 end
 
@@ -237,7 +237,7 @@ insertblock!(T::BlockSparseTensor, block) = insertblock!(T, Block(block))
     offset_of_block = insertblock_offset!(T, block)
     offset = offset_of_block+offset_within_block
   end
-  store(T)[offset] = val
+  storage(T)[offset] = val
   return T
 end
 
@@ -269,7 +269,7 @@ function blockview(T::BlockSparseTensor,
   blockT, offsetT = bof
   blockdimsT = blockdims(T, blockT)
   blockdimT = prod(blockdimsT)
-  dataTslice = @view data(store(T))[offsetT+1:offsetT+blockdimT]
+  dataTslice = @view data(storage(T))[offsetT+1:offsetT+blockdimT]
   return tensor(Dense(dataTslice), blockdimsT)
 end
 
@@ -1046,7 +1046,7 @@ reshape(T::BlockSparse, boffsR::BlockOffsets) =
 
 function reshape(T::BlockSparseTensor, boffsR::BlockOffsets,
                  indsR)
-  storeR = reshape(store(T),boffsR)
+  storeR = reshape(storage(T),boffsR)
   return tensor(storeR,indsR)
 end
 

--- a/src/blocksparse/diagblocksparse.jl
+++ b/src/blocksparse/diagblocksparse.jl
@@ -218,7 +218,7 @@ function DiagBlockSparseTensor(x::Number, blocks::Vector, inds)
   return tensor(storage,inds)
 end
 
-diagblockoffsets(T::DiagBlockSparseTensor) = diagblockoffsets(store(T))
+diagblockoffsets(T::DiagBlockSparseTensor) = diagblockoffsets(storage(T))
 
 """
 blockview(T::DiagBlockSparseTensor, block::Block)
@@ -236,7 +236,7 @@ function blockview(T::DiagBlockSparseTensor,
   blockT,offsetT = bof
   blockdimsT = blockdims(T,blockT)
   blockdiaglengthT = minimum(blockdimsT)
-  dataTslice = @view data(store(T))[offsetT+1:offsetT+blockdiaglengthT]
+  dataTslice = @view data(storage(T))[offsetT+1:offsetT+blockdiaglengthT]
   return tensor(Diag(dataTslice),blockdimsT)
 end
 
@@ -312,15 +312,15 @@ end
 function similar(T::DiagBlockSparseTensor{<:Number,N},
                       ::Type{ElR},
                       inds::Dims{N}) where {ElR<:Number,N}
-  return tensor(similar(store(T),ElR,minimum(inds)),inds)
+  return tensor(similar(storage(T),ElR,minimum(inds)),inds)
 end
 
-getdiagindex(T::DiagBlockSparseTensor{<:Number},ind::Int) = store(T)[ind]
+getdiagindex(T::DiagBlockSparseTensor{<:Number},ind::Int) = storage(T)[ind]
 
 # XXX: handle case of missing diagonal blocks
 function setdiagindex!(T::DiagBlockSparseTensor{<: Number},
                        val, ind::Int)
-  store(T)[ind] = val
+  storage(T)[ind] = val
   return T
 end
 
@@ -334,7 +334,7 @@ end
 getindex(T::DiagBlockSparseTensor{ElT,N},
               inds::Vararg{Int,N}) where {ElT,N}
   if all(==(inds[1]),inds)
-    return store(T)[inds[1]]
+    return storage(T)[inds[1]]
   else
     return zero(eltype(ElT))
   end
@@ -343,12 +343,12 @@ end
 @propagate_inbounds function
 getindex(T::DiagBlockSparseTensor{<:Number,1},
               ind::Int)
-  return store(T)[ind]
+  return storage(T)[ind]
 end
 
 @propagate_inbounds function
 getindex(T::DiagBlockSparseTensor{<:Number,0})
-  return store(T)[1]
+  return storage(T)[1]
 end
 
 # Set diagonal elements
@@ -358,7 +358,7 @@ setindex!(T::DiagBlockSparseTensor{<: Number, N},
                val,
                inds::Vararg{Int, N}) where {N}
   all(==(inds[1]),inds) || error("Cannot set off-diagonal element of DiagBlockSparse storage")
-  store(T)[inds[1]] = val
+  storage(T)[inds[1]] = val
   return T
 end
 
@@ -366,14 +366,14 @@ end
 setindex!(T::DiagBlockSparseTensor{<:Number, 1},
                val,
                ind::Int)
-  store(T)[ind] = val
+  storage(T)[ind] = val
   return T
 end
 
 @propagate_inbounds function
 setindex!(T::DiagBlockSparseTensor{<:Number,0},
                val)
-  store(T)[1] = val
+  storage(T)[1] = val
   return T
 end
 
@@ -384,7 +384,7 @@ function setindex!(T::UniformDiagBlockSparseTensor{<:Number, N},
 end
 
 # TODO: make a fill!! that works for uniform and non-uniform
-#fill!(T::DiagBlockSparseTensor,v) = fill!(store(T),v)
+#fill!(T::DiagBlockSparseTensor,v) = fill!(storage(T),v)
 
 function dense(::Type{<:Tensor{ElT,
                                N,

--- a/src/blocksparse/linearalgebra.jl
+++ b/src/blocksparse/linearalgebra.jl
@@ -77,7 +77,7 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
       if blockdim == 0
         push!(dropblocks,n)
       else
-        Strunc = tensor(Diag(store(Ss[n])[1:blockdim]),
+        Strunc = tensor(Diag(storage(Ss[n])[1:blockdim]),
                         (blockdim,blockdim))
         Us[n] = Us[n][1:dim(Us[n],1),1:blockdim]
         Ss[n] = Strunc
@@ -227,7 +227,7 @@ function LinearAlgebra.eigen(T::Union{Hermitian{ElT,<:BlockSparseMatrix{ElT}},
       if blockdim == 0
         push!(dropblocks,n)
       else
-        Dtrunc = tensor(Diag(store(Ds[n])[1:blockdim]),
+        Dtrunc = tensor(Diag(storage(Ds[n])[1:blockdim]),
                         (blockdim,blockdim))
         Ds[n] = Dtrunc
         Vs[n] = copy(Vs[n][1:dim(Vs[n],1),1:blockdim])

--- a/src/diag.jl
+++ b/src/diag.jl
@@ -201,7 +201,7 @@ end
 function similar(T::DiagTensor{<:Number,N},
                       ::Type{ElR},
                       inds::Dims{N}) where {ElR<:Number,N}
-  return tensor(similar(store(T),ElR,minimum(inds)),inds)
+  return tensor(similar(storage(T),ElR,minimum(inds)),inds)
 end
 
 """
@@ -209,14 +209,14 @@ getdiagindex(T::DiagTensor,i::Int)
 
 Get the ith value along the diagonal of the tensor.
 """
-getdiagindex(T::DiagTensor{<:Number},ind::Int) = store(T)[ind]
+getdiagindex(T::DiagTensor{<:Number},ind::Int) = storage(T)[ind]
 
 """
 setdiagindex!(T::DiagTensor,i::Int)
 
 Set the ith value along the diagonal of the tensor.
 """
-setdiagindex!(T::DiagTensor{<:Number},val,ind::Int) = (store(T)[ind] = val)
+setdiagindex!(T::DiagTensor{<:Number},val,ind::Int) = (storage(T)[ind] = val)
 
 """
 setdiag(T::UniformDiagTensor,val)
@@ -233,8 +233,8 @@ setdiag(T::UniformDiagTensor,val) = tensor(Diag(val),inds(T))
     return zero(eltype(ElT))
   end
 end
-@propagate_inbounds getindex(T::DiagTensor{<:Number,1},ind::Int) = store(T)[ind]
-@propagate_inbounds getindex(T::DiagTensor{<:Number,0}) = store(T)[1]
+@propagate_inbounds getindex(T::DiagTensor{<:Number,1},ind::Int) = storage(T)[ind]
+@propagate_inbounds getindex(T::DiagTensor{<:Number,0}) = storage(T)[1]
 
 # Set diagonal elements
 # Throw error for off-diagonal
@@ -244,15 +244,15 @@ end
   setdiagindex!(T,val,inds[1])
   return T
 end
-@propagate_inbounds setindex!(T::DiagTensor{<:Number,1},val,ind::Int) = ( store(T)[ind] = val )
-@propagate_inbounds setindex!(T::DiagTensor{<:Number,0},val) = ( store(T)[1] = val )
+@propagate_inbounds setindex!(T::DiagTensor{<:Number,1},val,ind::Int) = ( storage(T)[ind] = val )
+@propagate_inbounds setindex!(T::DiagTensor{<:Number,0},val) = ( storage(T)[1] = val )
 
 function setindex!(T::UniformDiagTensor{<:Number,N},val,inds::Vararg{Int,N}) where {N}
   error("Cannot set elements of a uniform Diag storage")
 end
 
 # TODO: make a fill!! that works for uniform and non-uniform
-#fill!(T::DiagTensor,v) = fill!(store(T),v)
+#fill!(T::DiagTensor,v) = fill!(storage(T),v)
 
 function dense(::Type{<:Tensor{ElT,N,StoreT,IndsT}}) where {ElT,N,
                                                             StoreT<:Diag,IndsT}

--- a/src/tensorstorage.jl
+++ b/src/tensorstorage.jl
@@ -43,11 +43,14 @@ end
 
 Base.conj!(S::TensorStorage) = (conj!(data(S)); return S)
 
-function Base.conj(S::T;always_copy = false) where {T<:TensorStorage} 
-  if always_copy
-    return conj!(copy(S))
-  end
-  return setdata(S,conj(data(S)))
+Base.conj(S::TensorStorage) = conj(AllowAlias(), S)
+
+function Base.conj(::AllowAlias, S::TensorStorage)
+  return setdata(S, conj(data(S)))
+end
+
+function Base.conj(::NeverAlias, S::TensorStorage)
+  return conj!(copy(S))
 end
 
 Base.complex(S::TensorStorage) = setdata(S,complex(data(S)))


### PR DESCRIPTION
This introduces `AliasStyle` with subtypes `AllowAlias` and `NeverAlias`, which helps distinguish between different versions of functions like `conj` or `Tensor` which may return copies or aliases of the input.